### PR TITLE
Added some constrast to the text of green pixels in background

### DIFF
--- a/_includes/sections/who-we-are.html
+++ b/_includes/sections/who-we-are.html
@@ -7,7 +7,7 @@
       We advise on sustainable practices, build capacity within organizations, and develop custom technologies to empower friends and neighbours–in the Great Lakes region and our virtual neighbourhoods.
     </h3>
 
-    <p class="measure-wide f4 f3-l lh-copy dark-gray">
+    <p class="measure-wide f4 f3-l lh-copy dark-gray bg-fade-white">
       As a non-profit worker co-operative, we strive to cultivate collective growth and meaningful livelihoods through learning and building digital technologies together.
     </p>
   </div>

--- a/_includes/sections/who-we-are.html
+++ b/_includes/sections/who-we-are.html
@@ -7,7 +7,7 @@
       We advise on sustainable practices, build capacity within organizations, and develop custom technologies to empower friends and neighbours–in the Great Lakes region and our virtual neighbourhoods.
     </h3>
 
-    <p class="measure-wide f4 f3-l lh-copy dark-gray bg-fade-white">
+    <p class="measure-wide f4 f3-l lh-copy dark-gray bg-white">
       As a non-profit worker co-operative, we strive to cultivate collective growth and meaningful livelihoods through learning and building digital technologies together.
     </p>
   </div>

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -47,7 +47,3 @@
     width: 70vw;
   }
 }
-
-.bg-fade-white {
-  background-color: hsla(0, 100%, 100%, 0.8);
-}

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -47,3 +47,7 @@
     width: 70vw;
   }
 }
+
+.bg-fade-white {
+  background-color: hsla(0, 100%, 100%, 0.8);
+}


### PR DESCRIPTION
Found contrast was a little tough to read through. Can we mute it or make the bg behind text totally white?

## Before (no alpha)

<img width="1010" alt="Screen Shot 2020-09-14 at 12 13 04 PM" src="https://user-images.githubusercontent.com/305339/93110694-ab1a5600-f683-11ea-9ebc-3f06b33a6c7c.png">

## After (0.8 alpha)

<img width="979" alt="Screen Shot 2020-09-14 at 11 40 18 AM" src="https://user-images.githubusercontent.com/305339/93110650-9d64d080-f683-11ea-874d-09a454ffabd4.png">

## Alternatives

0.9 alpha

<img width="1084" alt="Screen Shot 2020-09-14 at 12 15 28 PM" src="https://user-images.githubusercontent.com/305339/93110994-06e4df00-f684-11ea-8c24-689e0eb86432.png">

1.0 alpha

<img width="1025" alt="Screen Shot 2020-09-14 at 12 15 39 PM" src="https://user-images.githubusercontent.com/305339/93111008-0ba99300-f684-11ea-90c5-aafb1be80873.png">