### PR TITLE
Fixed font-face FOIT flicker in logotype on initial load.

### DIFF
--- a/_sass/_fonts.scss
+++ b/_sass/_fonts.scss
@@ -3,7 +3,7 @@
   font-weight: normal;
   src: url('../fonts/WorkSans-Regular.woff2') format('woff2'),
     url('../fonts/WorkSans-Regular.woff') format('woff');
-  font-display: auto;
+  font-display: optional;
 }
 
 @font-face {
@@ -11,5 +11,5 @@
   font-weight: 700;
   src: url('../fonts/WorkSans-Black.woff2') format('woff2'),
     url('../fonts/WorkSans-Black.woff') format('woff');
-  font-display: auto;
+  font-display: optional;
 }

--- a/_sass/_fonts.scss
+++ b/_sass/_fonts.scss
@@ -3,7 +3,7 @@
   font-weight: normal;
   src: url('../fonts/WorkSans-Regular.woff2') format('woff2'),
     url('../fonts/WorkSans-Regular.woff') format('woff');
-  font-display: swap;
+  font-display: auto;
 }
 
 @font-face {
@@ -11,5 +11,5 @@
   font-weight: 700;
   src: url('../fonts/WorkSans-Black.woff2') format('woff2'),
     url('../fonts/WorkSans-Black.woff') format('woff');
-  font-display: swap;
+  font-display: auto;
 }


### PR DESCRIPTION
| Screencast: Before | Screencast: After |
|---|---|
| [![screencast with font load flicker](http://g.recordit.co/FLBBAbyyLJ.gif)](https://recordit.co/FLBBAbyyLJ) | [![screencast without font load flicker](http://g.recordit.co/bzmHEvJA7l.gif)](https://recordit.co/bzmHEvJA7l)

Documentation of settings: https://css-tricks.com/almanac/properties/f/font-display/

Browser support: https://caniuse.com/css-font-rendering-controls