### PR TITLE
hypha.coop prorject - no HTTP serving

### DIFF
--- a/_scripts/config-dweb.json
+++ b/_scripts/config-dweb.json
@@ -3,8 +3,8 @@
   "publication": {
     "protocol": {
       "http": {
-          "enable": false,
-          "dnsupdate": false
+          "enabled": false,
+          "purgeIfDisabled": false
       }
     }
   }

--- a/_scripts/config-dweb.json
+++ b/_scripts/config-dweb.json
@@ -1,3 +1,11 @@
 {
-  "domain": "hypha.coop"
+  "domain": "hypha.coop",
+  "publication": {
+    "protocol": {
+      "http": {
+          "enable": false,
+          "dnsupdate": false
+      }
+    }
+  }
 }


### PR DESCRIPTION
References hyphacoop/distributed-press-organizing#34 

Update of config.json to prevent HTTP publishing and removal of A and AAAA records