### PR TITLE
Fix meta description attribute

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
 
   <meta property="og:title" content="{{ meta_title | escape }}">
   <meta name="description" content="{{ meta_description }}">
-  <meta property="og:description" content="{{ site_description }}">
+  <meta property="og:description" content="{{ meta_description }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
   <meta property="og:url" content="{{ site.url }}">
   <meta property="og:site_name" content="{{ meta_title | escape }}">
@@ -18,6 +18,7 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@HyphaCoop">
   <meta name="twitter:creator" content="@HyphaCoop">
+  <meta name="twitter:description" content="{{ meta_description }}">
   <meta name="twitter:image" content="{{ meta_image | relative_url }}">
   <meta name="theme-color" content="#9900FC">
 


### PR DESCRIPTION
Missed a couple instances of an update to use `meta_description` in #18. 