### PR TITLE
Assign dependabot PRs using dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+      
+    # Apply default reviewer to created pull requests
+    assignees:
+      - "ASoTNetworks"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler" 
+    directory: "/" 
     schedule:
       interval: "daily"
-      
     # Apply default reviewer to created pull requests
     assignees:
       - "ASoTNetworks"


### PR DESCRIPTION
Think this is better than using `CODEOWNERS`   (https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax) for targeting dependabot PRs.

Dependabot options: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem

