### PR TITLE
increased contrast to meet WCAG AA

### DIFF
--- a/_sass/tachyons-sass/scss/_variables.scss
+++ b/_sass/tachyons-sass/scss/_variables.scss
@@ -72,7 +72,7 @@ $black: #000 !default;
 $near-black: #111 !default;
 $dark-gray: #333 !default;
 $mid-gray: #555 !default;
-$gray: #777 !default;
+$gray: #666 !default;
 $silver: #999 !default;
 $light-silver: #aaa !default;
 $moon-gray: #ccc !default;


### PR DESCRIPTION
Changed the gray's value to a slightly darker one in order to meet the AA accessibility standard.
This is the gray that is used in the land acknowledgement in the footer.