### PR TITLE
Activity pub integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ gem "webrick", "~> 1.8"
 
 group :jekyll_plugins do
   gem "jekyll-feed", git: "https://github.com/hyphacoop/jekyll-feed"
+  gem 'jekyll-activity-pub', require: 'jekyll/activity_pub/commands'
 end

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ check: ## Check with htmlproofer
 	  --internal-domains hypha.coop
 
 build: ## Build for web
-	$(RUN) jekyll build
+	$(RUN) jekyll build --key ${{ secrets.DP_AP_KEY }}
 
-build-web: build
+build-web: build --key ${{ secrets.DP_AP_KEY }}
 
 relativize: ## Relativize links in _site
 	(cd _site && npx github:patcon/all-relative#also-root)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,4 +28,15 @@
   {% feed_meta %}
 
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}?{{ site.time | date: '%s%N' }}">
+
+  {% if page.activity %}
+    <link href="{{ page.activity.url | absolute_url }}" rel="alternate" type="application/activity+json" />
+  {% endif %}
+
+  <meta property="profile:username" content="{{ site.activity_pub_profile }}" />
+
+  {%- if site.actor -%}
+    <link rel="me" href="{{ site.actor.url | absolute_url }}" />
+  {%- endif -%}
+
 </head>


### PR DESCRIPTION
I did the following steps as seen in [these instructions](https://0xacab.org/sutty/jekyll/jekyll-activity-pub/-/blob/antifascista/_docs/social_distributed_press.md?ref_type=heads)

- Installed the plugin by adding it to our `Gemfile`
- Generated a private key and added it to GH secrets
- Added the new `key` flag to `jekyll build` in the `Makefile`
- Added relevant links and meta properties to the site's head [as seen on this document](https://0xacab.org/sutty/jekyll/jekyll-activity-pub/-/blob/antifascista/_docs/site.md?ref_type=heads)

Once this is published and propagated, I will run the jekyll notify command.

`bundle exec jekyll notify --key ${{ secrets.DP_AP_KEY }}`

Should the above command be added to the Makefile?

Anything else that I missed?
