### PR TITLE
Add posting for Senior Operations and Finance Lead role

### DIFF
--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -100,6 +100,10 @@ notifications:
     action: done
     id: https://hypha.coop/dripline/announcing-dp-social-inbox/
     created_at: 1701786255
-actor_url: https://hypha.coop/about.jsonld
-actor: "@dripline@hypha.coop"
-public_key_url: https://hypha.coop/about.jsonld#main-key
+  openings/senior-ops-finance.jsonld:
+    action: done
+    id: https://staging.hypha.coop/openings/senior-ops-finance/
+    created_at: 1702587961
+actor_url: https://staging.hypha.coop/about.jsonld
+actor: "@dripline@staging.hypha.coop"
+public_key_url: https://staging.hypha.coop/about.jsonld#main-key

--- a/_openings/senior-ops-finance.md
+++ b/_openings/senior-ops-finance.md
@@ -1,0 +1,91 @@
+---
+title: Senior Operations & Finance Lead 
+prepared-on-date: 2023-12-14
+excerpt_separator: <!-- more -->
+excerpt: "<p>Duties include risk assessment, co-operative law compliance, talent acquisition, incentive programs, treasury management, decision-making efficiency, and accountability systems.</p>"
+---
+
+## Overview
+
+**Location:** Remote  
+**Compensation:** $122,805-$142,454 CAD annually  
+**Time commitment:** 4 days/week  
+**Application deadline:**  Rolling until filled (if you see this on our website, the position is still open)  
+**Start date:** Late January 2024
+
+[Hypha Worker Co-operative](https://hypha.coop) (Hypha) is looking for an experienced senior operations and finance lead. This is a management-level position that requires 8-10 years of relevant work experience. Candidates must be well-versed in managing all aspects of a small organization’s financial matters, as well as managing and improving internal operations processes. You must be a strategic thinker, able to see how your work connects to our core business, while equally comfortable rolling up your sleeves and moving deliverables over the finish line.  
+
+
+This is a new full-time position, and the work is currently being executed by a Finance Working Group and an Operations Working Group. You will assume the leadership of these groups and will be responsible for ensuring continuous improvements and strategic alignment in both these areas. As a small organization, project and group leads are responsible both for guiding the direction of their areas as well as actively doing the work itself.  
+
+
+Hypha is a co-operative, so we do things [a little differently](https://hypha.coop/dripline/how-we-co-operate/"). Ideally, you are excited about participating in a co-operative, building the solidarity economy, and engaging in discussions on rethinking social structures and the politics of technologies.  
+
+
+Given our unique form (worker-managed consultancy) and the domains we work in (emerging technologies), you'll play a central role in improving the structure of our organization. Duties include risk assessment, co-operative law compliance, talent acquisition, incentive programs, treasury management, decision-making efficiency, and accountability systems. Your active involvement will contribute to shaping Hypha as an "organization in beta."  
+
+
+## Here are some of the things you’ll do
+
+You will work with the Operations and Finance Working Groups and project leads to fulfill a range of responsibilities:
+
+* Develop operational strategies that align with Hypha’s business goals  
+* Liaise with the Strategy Working Group to deliver relevant financial forecasts and other reports that present a coherent picture of the co-operative’s financial health  
+* Manage risk by regularly reviewing and updating contracts, agreements, policies, and operational security practices to address legal and compliance requirements  
+* Lead the Finance Working Group and liaise with the bookkeeper and accountant to process invoices, make payments, and track receipts, and develop fiscal forecasting tools  
+* Oversee our fiscal sponsorship program on Open Collective
+* Lead the Operations Working Group and improve talent acquisition and retention by developing better hiring practices and HR policies  
+* Support various project teams in their financial and operational needs while you become more familiar with how our co-operative functions. This work involves understanding the technology and process work that Hypha offers as a consultancy, and familiarizing yourself with decentralized web technologies that make up the core of our business
+* Iterate on current initiatives that help build up our organizational culture  
+* Organize key in person events including our annual retreat and member meetings  
+
+
+## Qualifications and skills we are looking for
+
+
+* A minimum of 8 years experience managing operational, forecasting, and budgeting processes, ideally in a small and fast moving organization  
+* Exceptionally organized and highly detail-oriented. You can spot a typo or rounding error from a kilometre away  
+* Extreme spreadsheet proficiency. We rely on spreadsheets with advanced functions (query, vlookup, importrange) to automate our tracking. You will need to be able to interpret and improve existing spreadsheets as well as develop and communicate about your own  
+* Self-managing and self-motivated; you must be comfortable collaborating with working groups (small committees), while also initiating process changes and innovations  
+* Ability to work independently and participate collaboratively in a distributed team environment by being active and engaged online in our group chats and other collaborative tools    
+* The position is remote-only, and experience in a remote-first organization is a must  
+* Experience in a horizontal or flat organization is considered a plus  
+* Knowledge of cryptocurrencies and Web3 technology is a huge asset  
+* Excellent time management skills and the ability to prioritize work  
+* Able to manage multiple tasks and deliverables with ease  
+* Clear and compassionate oral and written communication skills  
+* Demonstrated commitment to the principles of equity and diversity with alignment on Hypha’s [mission and values](https://handbook.hypha.coop/vision.html)
+
+
+## More about us
+
+[Hypha Worker Co-operative](https://hypha.coop/) is a non-profit worker co-op based in Tkaronto (Toronto). We collaborate with communities to build better relationships with technology. Hypha specializes in applied cryptography, peer-to-peer technologies, distributed network operation and governance. We work on local-first software, interoperable blockchain projects, data provenance, technical capacity development and governance strategies for decentralized communities. You can read more about our mission, vision, and values, and how we work together in [our organizational handbook](https://handbook.hypha.coop/) and on our [GitHub organization](https://github.com/hyphacoop). 
+
+As a remote-first organization that strives toward sustainable livelihoods for all our members, we accommodate flexible schedules and work arrangements. We are committed to [the co-operative principles](https://www.ica.coop/en/cooperatives/cooperative-identity), which provide a pathway for all employees to permanent membership. We are looking to build long-term relationships with contractors who are potentially interested in joining our co-operative as a member in the future. **If working openly on value-driven technology is your jam, let’s talk!**
+
+## Location
+
+Remote position, with a preference for Tkaronto-based people.
+
+## Compensation
+
+Annual rate of $122,805-$142,454 CAD, depending on experience.
+
+## Hours and contract term
+
+Work completed Monday to Friday, for a total of 32 hours per week.  
+
+
+This is a full time position.  
+
+## Process to apply
+
+To be considered, please email us at [hiring@hypha.coop](mailto:hiring@hypha.coop) with the following **before** January 15, 2024:
+
+* CV (ideally as a PDF)
+* Brief covering statement (in email body is fine) outlining why you are a fit for the position, this could include:
+    * Description of relevant and recent work
+    * Mention of how you heard about this position (e.g., job board, listserv, etc.)
+* If you would like us to keep your information on file for future opportunities
+
+*Hypha strives to cultivate collective and inclusive growth in our communities, and to support meaningful livelihoods for our members. We offer a respectful and open workplace. Hypha upholds accessibility, diversity, and equal opportunity in our hiring practices. Requests for accommodations can be made at any stage of the recruitment process.*

--- a/_openings/senior-ops-finance.md
+++ b/_openings/senior-ops-finance.md
@@ -19,7 +19,7 @@ excerpt: "<p>Duties include risk assessment, co-operative law compliance, talent
 This is a new full-time position, and the work is currently being executed by a Finance Working Group and an Operations Working Group. You will assume the leadership of these groups and will be responsible for ensuring continuous improvements and strategic alignment in both these areas. As a small organization, project and group leads are responsible both for guiding the direction of their areas as well as actively doing the work itself.  
 
 
-Hypha is a co-operative, so we do things [a little differently](https://hypha.coop/dripline/how-we-co-operate/"). Ideally, you are excited about participating in a co-operative, building the solidarity economy, and engaging in discussions on rethinking social structures and the politics of technologies.  
+Hypha is a co-operative, so we do things [a little differently](https://hypha.coop/dripline/how-we-co-operate/). Ideally, you are excited about participating in a co-operative, building the solidarity economy, and engaging in discussions on rethinking social structures and the politics of technologies.  
 
 
 Given our unique form (worker-managed consultancy) and the domains we work in (emerging technologies), you'll play a central role in improving the structure of our organization. Duties include risk assessment, co-operative law compliance, talent acquisition, incentive programs, treasury management, decision-making efficiency, and accountability systems. Your active involvement will contribute to shaping Hypha as an "organization in beta."  


### PR DESCRIPTION
Imported from the google doc.
- Added `CAD` next to salary range
- I removed and before technical capacity in the following sentence:

> We work on local-first software, interoperable blockchain projects, data provenance, and technical capacity development and governance strategies for decentralized communities.

So now it is like this:

> We work on local-first software, interoperable blockchain projects, data provenance, technical capacity development and governance strategies for decentralized communities.
