### PR TITLE
Hide restructuring futures from the homepage and replace with FoH

### DIFF
--- a/_work/friends-of-hek.md
+++ b/_work/friends-of-hek.md
@@ -1,6 +1,7 @@
 ---
 title: FRIENDS OF HEK
 logo: /assets/images/logos/friends-of-hek-logo.png
+preview: true
 work-type: 
     - Blockchain development
     - Community stewardship

--- a/_work/restructuring-futures.md
+++ b/_work/restructuring-futures.md
@@ -1,7 +1,7 @@
 ---
 title: Restructuring Futures
 logo: /assets/images/logos/ccfa-logo.png
-preview: true
+preview: false
 work-type: 
     - Alternative economies 
     - Embodied creation 


### PR DESCRIPTION
Hide RSF and replace with FoH on the homepage 'Selected Projects'