### PR TITLE
Add rel=me link to head.html for Co-social profile verification

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ phone: +1 437-887-6936
 address: Toronto, ON
 github: https://github.com/hyphacoop
 linkedin: https://www.linkedin.com/company/hyphacoop/
+mastodon: https://cosocial.ca/@hyphacoop
 twitter: https://twitter.com/hyphacoop/
 handbook: https://link.hypha.coop/handbook
 rss: "/feed.xml"

--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -108,6 +108,6 @@ notifications:
     action: done
     id: https://hypha.coop/openings/test-engineer/
     created_at: 1704749005
-actor_url: https://hypha.coop/about.jsonld
-actor: "@dripline@hypha.coop"
-public_key_url: https://hypha.coop/about.jsonld#main-key
+actor_url: https://staging.hypha.coop/about.jsonld
+actor: "@dripline@staging.hypha.coop"
+public_key_url: https://staging.hypha.coop/about.jsonld#main-key

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,7 +25,8 @@
   <meta name="theme-color" content="#9900FC">
   <link rel="preload" as="font" href="/assets/fonts/WorkSans-VariableFont_wght.woff2" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" as="font" href="/assets/fonts/WorkSans-Italic-VariableFont_wght.woff2" type="font/woff2" crossorigin="anonymous">
-
+  <link href="https://cosocial.ca/@hyphacoop" rel="me">
+  
   {% feed_meta %}
 
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}?{{ site.time | date: '%s%N' }}">

--- a/_includes/sections/footer.html
+++ b/_includes/sections/footer.html
@@ -5,7 +5,7 @@
       <li class="pr3"><a href="{{ site.github }}" class="accent link underline-hover" target="_blank" rel="noopener">GitHub</a></li>
       <li class="pr3"><a href="{{ site.linkedin }}" class="accent link underline-hover" target="_blank" rel="noopener" data-proofer-ignore>LinkedIn</a></li>
       <li class="pr3"><a href="{{ site.twitter }}" class="accent link underline-hover" target="_blank" rel="noopener">Twitter</a></li>
-      <li class="pr3"><a href="{{ site.mastodon }}" class="accent link underline-hover" target="_blank" rel="me">Mastodon</a></li>
+      <li class="pr3"><a href="{{ site.mastodon }}" class="accent link underline-hover" target="_blank" rel="noopener me">Mastodon</a></li>
       <li class="pr3"><a href="{{ site.handbook }}" class="accent link underline-hover" target="_blank" rel="noopener">Handbook</a></li>
       <li class="pr3"><a href="{{ site.url }}{{ site.rss }}" class="accent link underline-hover" target="_blank" rel="noopener">
         RSS

--- a/_includes/sections/footer.html
+++ b/_includes/sections/footer.html
@@ -5,6 +5,7 @@
       <li class="pr3"><a href="{{ site.github }}" class="accent link underline-hover" target="_blank" rel="noopener">GitHub</a></li>
       <li class="pr3"><a href="{{ site.linkedin }}" class="accent link underline-hover" target="_blank" rel="noopener" data-proofer-ignore>LinkedIn</a></li>
       <li class="pr3"><a href="{{ site.twitter }}" class="accent link underline-hover" target="_blank" rel="noopener">Twitter</a></li>
+      <li class="pr3"><a href="{{ site.mastodon }}" class="accent link underline-hover" target="_blank" rel="me">Mastodon</a></li>
       <li class="pr3"><a href="{{ site.handbook }}" class="accent link underline-hover" target="_blank" rel="noopener">Handbook</a></li>
       <li class="pr3"><a href="{{ site.url }}{{ site.rss }}" class="accent link underline-hover" target="_blank" rel="noopener">
         RSS


### PR DESCRIPTION
This addition to our head.html was created after receiving a message from Boris via the CoSocial Community Cooperative account.

> 
> One of the things we’re trying to do for organizations is to get them to verify at least one link in their profile. 
> 
> Would be great if you added the appropriate rel=me links to the Hypha home page to get your profile green check.

We might also want to consider adding a visible link to our mastodon account in the footer of hypha.coop as this implementation currently does not lead to any visible link on our homepage.