### PR TITLE
Bump jekyll-activity-pub from 0.2.9 to 0.2.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-activity-pub (0.2.9)
+    jekyll-activity-pub (0.2.10)
       distributed-press-api-client (~> 0.4.2)
       jekyll (~> 4)
       marcel (~> 1)


### PR DESCRIPTION
This new version fixes the white-space bug that occured when using lists

> Every time we use bullets in an article, they appear with a few blank spaces in the Fedi account.