### PR TITLE
Update jekyll activity pub to 0.3.0rc0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
     csv (3.3.0)
-    distributed-press-api-client (0.5.0rc2)
+    distributed-press-api-client (0.5.0rc3)
       addressable (~> 2.3, >= 2.3.0)
       climate_control
       dry-schema

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
     csv (3.3.0)
-    distributed-press-api-client (0.5.0rc1)
+    distributed-press-api-client (0.5.0rc2)
       addressable (~> 2.3, >= 2.3.0)
       climate_control
       dry-schema
@@ -145,7 +145,7 @@ GEM
     unicode-display_width (2.5.0)
     webrick (1.8.1)
     yell (2.2.2)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,11 +11,12 @@ GEM
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.8)
     climate_control (1.2.0)
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
-    distributed-press-api-client (0.4.2)
+    csv (3.3.0)
+    distributed-press-api-client (0.5.0rc1)
       addressable (~> 2.3, >= 2.3.0)
       climate_control
       dry-schema
@@ -35,7 +36,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-schema (1.13.3)
+    dry-schema (1.13.4)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 1.0, >= 1.0.1)
       dry-core (~> 1.0, < 2)
@@ -67,7 +68,8 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.8.0)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httparty-cache (0.0.6)
@@ -90,8 +92,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-activity-pub (0.2.10)
-      distributed-press-api-client (~> 0.4.2)
+    jekyll-activity-pub (0.3.0rc0)
+      distributed-press-api-client (~> 0.5.0rc1)
       jekyll (~> 4)
       marcel (~> 1)
     jekyll-sass-converter (2.2.0)
@@ -143,7 +145,7 @@ GEM
     unicode-display_width (2.5.0)
     webrick (1.8.1)
     yell (2.2.2)
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.15)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Ran into this error after update 

```
/var/lib/gems/3.0.0/gems/distributed-press-api-client-0.5.0rc1/lib/distributed_press/v1/social/replies.rb:41:in `endpoint': undefined method `encode_uri_component' for URI:Module (NoMethodError)
Did you mean?  encode_www_form_component

```

Bumped distributed-press-api-client to resolve the no method error

Thanks to Fauno.