### PR TITLE
Refactor deployment to include environment variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,12 +61,12 @@ jobs:
         run: echo ${{ secrets.ENCODED_DP_AP_KEY_PRODUCTION }} | base64 --decode > /tmp/secret.key
 
       - name: Build Jekyll Site for Staging
-        if: github.ref == 'refs/heads/staging'
+        if: github.ref == 'refs/heads/staging' || (github.event_name == 'pull_request' && github.base_ref == 'staging')
         run: |
           JEKYLL_ENV=staging make build-dweb
       
       - name: Build Jekyll Site for Production
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.base_ref == 'master')
         run: |
           make build-dweb
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,15 @@ jobs:
           (github.event_name == 'pull_request' && github.base_ref == 'master')
         run: echo ${{ secrets.ENCODED_DP_AP_KEY_PRODUCTION }} | base64 --decode > /tmp/secret.key
 
-      - run: make build-dweb
+      - name: Build Jekyll Site for Staging
+        if: github.ref == 'refs/heads/staging'
+        run: |
+          JEKYLL_ENV=staging make build-dweb
+      
+      - name: Build Jekyll Site for Production
+        if: github.ref == 'refs/heads/master'
+        run: |
+          make build-dweb
 
       - run: make check
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,6 @@ jobs:
       - run: sudo gem install jekyll
       - run: sudo bundle install
 
-      - name: Set Site URL based on branch
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
-            sed -i 's|url: "https://staging.hypha.coop"|url: "https://hypha.coop"|' _config.yml
-          fi
-
       - name: Set DP Social URL based on branch
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ check: ## Check with htmlproofer
 	  --internal-domains hypha.coop
 
 build: ## Build for web
-	$(RUN) jekyll build --config _config.yml$(if $(JEKYLL_ENV),,_config_$(JEKYLL_ENV).yml) --key /tmp/secret.key
+	@if [ "$(JEKYLL_ENV)" = "staging" ]; then \
+		$(RUN) jekyll build --config _config.yml,_config_staging.yml --key /tmp/secret.key; \
+	else \
+		$(RUN) jekyll build --config _config.yml --key /tmp/secret.key; \
+	fi
 
 build-web: build
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check: ## Check with htmlproofer
 	  --internal-domains hypha.coop
 
 build: ## Build for web
-	bundle exec jekyll build --key /tmp/secret.key
+	$(RUN) jekyll build --config _config.yml$(if $(JEKYLL_ENV),,_config_$(JEKYLL_ENV).yml) --key /tmp/secret.key
 
 build-web: build
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ mastodon: https://cosocial.ca/@hyphacoop
 twitter: https://twitter.com/hyphacoop/
 handbook: https://link.hypha.coop/handbook
 rss: "/feed.xml"
-url: https://staging.hypha.coop
+url: "https://hypha.coop"
 footer: Hypha Worker Co-operative Inc.<br>Ontario Corporation No. 5019866
 
 description: >-

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,0 +1,1 @@
+url: "https://staging.hypha.coop"


### PR DESCRIPTION
Refactor deployment to build site with environment variables for branch-specific configs

- Updated Makefile to properly handle JEKYLL_ENV for staging builds.
- Added _config_staging.yml for staging-specific settings.
- Updated _config.yml to use hypha.coop as the default production URL. It will be overwritten to staging.hypha.coop when the base branch is staging.