### PR TITLE
Adjust practice area titles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,15 +90,15 @@ jobs:
           refresh_token: ${{ secrets.DISTRIBUTED_PRESS_PRODUCTION_TOKEN}}
           site_url: hypha.coop
 
-      - name: Notify AP
-        run: bundle exec jekyll notify --key /tmp/secret.key --verbose --trace
-
-      - name: Commit ActivityPub Data
-        uses: EndBug/add-and-commit@v9 
-        with:
-          add: '_data/activity_pub.yml'
-          default_author: github_actions
-          message: 'Commit ActivityPub Data'
-          fetch: true
+#      - name: Notify AP
+#        run: bundle exec jekyll notify --key /tmp/secret.key --verbose --trace
+#
+#     - name: Commit ActivityPub Data
+#        uses: EndBug/add-and-commit@v9 
+#        with:
+#          add: '_data/activity_pub.yml'
+#          default_author: github_actions
+#          message: 'Commit ActivityPub Data'
+#          fetch: true
 
 

--- a/_includes/sections/what-we-do.html
+++ b/_includes/sections/what-we-do.html
@@ -7,9 +7,6 @@
     </p>
   </div>
 </div>
-<h2 class="f2 accent mb2">
-  Our practice areas
-</h2>
 <div class="flex flex-between justify-between flex-wrap">
   {% assign sorted_elements = page.what_we_do | sort: 'order' %}
   {% for element in sorted_elements %}

--- a/_includes/sections/what-we-do.html
+++ b/_includes/sections/what-we-do.html
@@ -11,7 +11,7 @@
   {% assign sorted_elements = page.what_we_do | sort: 'order' %}
   {% for element in sorted_elements %}
     <div class="w-30-l measure flex-column justify-left items-left tl pr4">
-      <h3 class="f3 accent">{{ element.title }}</h3>
+      <h2 class="f2 accent mb1">{{ element.title }}</h2>
       <p class="pb3 f3 lh-copy">
         {{ element.description }}
       

--- a/_includes/sections/what-we-do.html
+++ b/_includes/sections/what-we-do.html
@@ -3,7 +3,7 @@
       <h2>What we do</h2>
     <p class="lh-copy f3 measure mt0">
       We’re a diverse team of expert creatives, builders, and organizers who collaborate closely with clients to advance their missions through tech. Read more about
-      <a class="accent link underline-hover" href="/work/">our work</a>.
+      <a class="accent link underline-hover" href="/work/">our work</a>  across Hypha's three practice areas.
     </p>
   </div>
 </div>


### PR DESCRIPTION
- Removes 'Our practice areas' title
- Edit `What we do` to mention Hypha's three practice area
- Increase practice area title size
- Pause activity pub notify and commit until it is fixed