### PR TITLE
Update webrick dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (2.6.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     yell (2.2.2)
     zeitwerk (2.6.17)
 

--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -146,6 +146,6 @@ notifications:
     action: done
     id: https://staging.hypha.coop/dripline/storing-metadata-at-starling-lab.jsonld
     created_at: 1728400393
-actor_url: https://staging.hypha.coop/about.jsonld
-actor: "@dripline@staging.hypha.coop"
-public_key_url: https://staging.hypha.coop/about.jsonld#main-key
+actor_url: https://hypha.coop/about.jsonld
+actor: "@dripline@hypha.coop"
+public_key_url: https://hypha.coop/about.jsonld#main-key


### PR DESCRIPTION
- Bump webrick from 1.8.1 to 1.8.2

- Merging this pull request would fix [1 Dependabot alert](https://github.com/hyphacoop/hypha.coop/security/dependabot?q=is%3Aopen+package%3Awebrick+manifest%3AGemfile.lock+has%3Apatch) on webrick in [Gemfile.lock](https://github.com/hyphacoop/hypha.coop/blob/-/Gemfile.lock).

   - `HTTP Request Smuggling in ruby webrick `