### PR TITLE
Bluesky replies

### DIFF
--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -138,6 +138,6 @@ notifications:
     id: https://hypha.coop/dripline/dweb-camp-recap-a-cybernetic-ecology.jsonld
     created_at: 1732545569
     last_modified_at: 1732631737
-actor_url: https://hypha.coop/about.jsonld
-actor: "@dripline@hypha.coop"
-public_key_url: https://hypha.coop/about.jsonld#main-key
+actor_url: https://staging.hypha.coop/about.jsonld
+actor: "@dripline@staging.hypha.coop"
+public_key_url: https://staging.hypha.coop/about.jsonld#main-key

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,4 +63,6 @@
     <link rel="me" href="{{ site.actor.url[0].href }}" />
   {%- endif -%}
 
+  <link rel="stylesheet" href="https://unpkg.com/bluesky-comments@latest/dist/bluesky-comments.css">
+
 </head>

--- a/_layouts/dripline/post.html
+++ b/_layouts/dripline/post.html
@@ -21,6 +21,15 @@ layout: default
   <article id="dripline" class="mw8 center">
     {{ content }}
   </article>
+  <div id="bluesky-comments"></div>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/bluesky-comments@latest/dist/bluesky-comments.umd.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        initBlueskyComments('bluesky-comments', {author: 'hypha.coop'});
+    });
+  </script>
   <footer class="mt5 bt bw2 b--light-gray">
     <p><a class="link accent underline-hover" href="{% link dripline.html %}">← <span class="gray">Return to Dripline</span></a></p>
   </footer>


### PR DESCRIPTION
- Implements support for bluesky replies on Dripline

From https://www.coryzue.com/writing/bluesky-comments/

How to:

- Simply share the link to a dripline post on Bluesky from Hypha's account and replies will/ should appear on the website.