### PR TITLE
Fix dripline page layout

### DIFF
--- a/_sass/tachyons-sass/scss/_widths.scss
+++ b/_sass/tachyons-sass/scss/_widths.scss
@@ -71,6 +71,13 @@
 .w-90 {  width:  90%; }
 .w-100 { width: 100%; }
 
+.w-fill-available { 
+  width: 100%;
+  width: -moz-available;          
+  width: -webkit-fill-available; 
+  width: fill-available; 
+}
+
 .w-third { width: calc(100% / 3); }
 .w-two-thirds { width: calc(100% / 1.5); }
 .w-auto { width: auto; }

--- a/dripline.html
+++ b/dripline.html
@@ -43,7 +43,7 @@ order: 4
   {%- if posts.size > 0 -%}
   <article class="flex flex-wrap justify-center">
     {%- assign date_format = site.date_format -%} {%- for post in posts -%}
-    <div class="bg-white measure pv3 pr6-l pl0-l pr0-s pl0-s center mb4 db">
+    <div class="bg-white measure pv3 pr6-l pl0-l pr0-s pl0-s center mb4 db w-fill-available">
       <a class="no-underline" href="{{ post.url | relative_url }}">
         <h3
           class="f3 mt0 mb2 sans-serif normal accent link underline-hover lh-title"


### PR DESCRIPTION
- Creates `w-fill-available` css class
- Adds this new class to the article elements on the dripline page

Fixes #424 