### PR TITLE
Fix: ID location for workers on People 

### DIFF
--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -146,6 +146,6 @@ notifications:
     action: done
     id: https://hypha.coop/dripline/co-operative-cats-and-deliberative-dashboards.jsonld
     created_at: 1738164141
-actor_url: https://staging.hypha.coop/about.jsonld
-actor: "@dripline@staging.hypha.coop"
-public_key_url: https://staging.hypha.coop/about.jsonld#main-key
+actor_url: https://hypha.coop/about.jsonld
+actor: "@dripline@hypha.coop"
+public_key_url: https://hypha.coop/about.jsonld#main-key

--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -146,6 +146,6 @@ notifications:
     action: done
     id: https://hypha.coop/dripline/co-operative-cats-and-deliberative-dashboards.jsonld
     created_at: 1738164141
-actor_url: https://hypha.coop/about.jsonld
-actor: "@dripline@hypha.coop"
-public_key_url: https://hypha.coop/about.jsonld#main-key
+actor_url: https://staging.hypha.coop/about.jsonld
+actor: "@dripline@staging.hypha.coop"
+public_key_url: https://staging.hypha.coop/about.jsonld#main-key

--- a/_includes/sections/team-bios.html
+++ b/_includes/sections/team-bios.html
@@ -1,7 +1,7 @@
 <div class="flex flex-wrap justify-start mb4 contain">
   {% for person in site.people %}
   {% if person.hidden != true %}
-  <article class="w-33-l pv3-ns ph5-ns mb4 center-m ml0-l">
+  <article class="w-33-l pv3-ns ph5-ns mb4 center-m ml0-l" id="{{ person.name }}">
     <div class="flex items-end">
       <img src="/assets/images/avatars/{{ person.avatar }}" alt="{{ person.name }}" class="w4 tc white f3 v-mid h4">
       <div class="pl4 w-50 pt0 pt0-l v-btm pb0">
@@ -13,7 +13,6 @@
     </div>
     <div
       class="lh-copy measure center f5 pt3"
-      id="{{ person.name }}"
     >
       <div
         class="bio-content"


### PR DESCRIPTION
We can link to individual sections of the people page.

I noticed the ID is set on the text content but for better visibility it should be set on the parent container.

I moved it to the parent 'article' element.

This will give a better result when linking to someone's section


This was discovered through an IPFS post that linked to https://hypha.coop/people/#Cole%20Anthony%20Capilongo
Notice the image is left out of screen. This change will allow to have such a link point to a page position where the avatar image is in browser's view.