### PR TITLE
a11y: underline links 

### DIFF
--- a/_includes/sections/footer.html
+++ b/_includes/sections/footer.html
@@ -4,23 +4,23 @@
     <div class="w-100 w-50-l pr5">
       <nav aria-label="Social media links">
         <ul class="list pl0 flex flex-wrap f5 f4-l items-center">
-          <li class="pr3 pr4-ns mb3"><a href="{{ site.github }}" class="accent link underline-hover" target="_blank"
+          <li class="pr3 pr4-ns mb3"><a href="{{ site.github }}" class="accent link" target="_blank"
               rel="noopener" aria-label="Visit our GitHub profile">
               <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/github_logo.svg" alt="GitHub">
             </a></li>
-          <li class="pr3 pr4-ns mb3"><a href="{{ site.linkedin }}" class="accent link underline-hover" target="_blank"
+          <li class="pr3 pr4-ns mb3"><a href="{{ site.linkedin }}" class="accent link" target="_blank"
               rel="noopener" data-proofer-ignore aria-label="Visit our LinkedIn profile">
               <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/linkedin_logo.svg" alt="LinkedIn">
             </a></li>
-          <li class="pr3 pr4-ns mb3"><a href="{{ site.bluesky }}" class="accent link underline-hover" target="_blank"
+          <li class="pr3 pr4-ns mb3"><a href="{{ site.bluesky }}" class="accent link" target="_blank"
               rel="noopener" data-proofer-ignore aria-label="Visit our Bluesky profile">
               <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/bluesky_logo.svg" alt="Bluesky">
             </a></li>
-          <li class="pr3 pr4-ns mb3"><a href="{{ site.mastodon }}" class="accent link underline-hover" target="_blank"
+          <li class="pr3 pr4-ns mb3"><a href="{{ site.mastodon }}" class="accent link" target="_blank"
               rel="noopener me" aria-label="Visit our Mastodon profile">
               <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/mastodon_logo.svg" alt="Mastodon">
             </a></li>
-          <li class="pr3 pr4-ns mb3"><a href="{{ site.url }}{{ site.rss }}" class="accent link underline-hover"
+          <li class="pr3 pr4-ns mb3"><a href="{{ site.url }}{{ site.rss }}" class="accent link"
               target="_blank" rel="noopener" aria-label="Subscribe to our RSS feed">
               <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/rss_logo.svg" alt="RSS">
             </a></li>
@@ -28,11 +28,11 @@
       </nav>
       <nav aria-label="Footer links">
         <ul class="list pl0 flex flex-wrap f5 f4-l items-center">
-          <li class="pr3"><a href="{{ site.handbook }}" class="accent link underline-hover" target="_blank"
+          <li class="pr3"><a href="{{ site.handbook }}" class="accent link" target="_blank"
             rel="noopener" aria-label="Read our handbook">
             Handbook
           </a></li>
-          <li class="pr3"><a href="{{ site.newsletter }}" class="accent link underline-hover" target="_blank"
+          <li class="pr3"><a href="{{ site.newsletter }}" class="accent link" target="_blank"
             rel="noopener" aria-label="Subscribe to our newsletter">
             Newsletter
           </a></li>
@@ -41,20 +41,20 @@
       <div role="region" aria-labelledby="policies-heading">
         <h2 id="policies-heading" class="dn">Policies and Licensing Information</h2>
         <p class="f6 f5-l lh-copy">Data and privacy policies are in our handbook: <a
-            href="https://handbook.hypha.coop/Policies/data.html" target="_blank" class="accent link underline-hover"
+            href="https://handbook.hypha.coop/Policies/data.html" target="_blank" class="accent link"
             rel="noopener">How We Use Data</a> and <a href="https://handbook.hypha.coop/Policies/working-open.html"
-            target="_blank" class="accent link underline-hover" rel="noopener">Working Open</a>.</p>
+            target="_blank" class="accent link" rel="noopener">Working Open</a>.</p>
         <p class="f6 f5-l lh-copy">
           This site is published using <a href="https://distributed.press/" target="_blank"
-            class="accent link underline-hover" rel="noopener">Distributed Press</a>.
+            class="accent link" rel="noopener">Distributed Press</a>.
           You can <a href="https://github.com/hyphacoop/api.distributed.press" target="_blank"
-            class="accent link underline-hover" rel="noopener">use it to publish</a> on the p2p and distributed web too.
+            class="accent link" rel="noopener">use it to publish</a> on the p2p and distributed web too.
           Distributed Web:
-          <a href="https://ipfs.distributed.press/ipns/hypha.coop{{ page.url }}" class="accent link underline-hover"
+          <a href="https://ipfs.distributed.press/ipns/hypha.coop{{ page.url }}" class="accent link"
             data-proofer-ignore>ipns://hypha.coop</a>
         </p>
         <p class="f6 f5-l lh-copy">This website content is licensed under a <a
-            href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" class="accent link underline-hover"
+            href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" class="accent link"
             rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a> license.</p>
       </div>
     </div>

--- a/_includes/sections/header.html
+++ b/_includes/sections/header.html
@@ -12,4 +12,4 @@
 </div>
 
 
-<a href="#menu" aria-label="Open menu" class="dn-l f4 f3-ns link underline-hover accent sans-serif">Menu</a>
+<a href="#menu" aria-label="Open menu" class="dn-l f4 f3-ns no-underline underline-hover accent sans-serif">Menu</a>

--- a/_includes/sections/join-the-team.html
+++ b/_includes/sections/join-the-team.html
@@ -19,7 +19,7 @@
       <div class="measure w-33-m w-33-l w100 pr3 pl3 mb3">
         <a class="no-underline" href="{{ opening.url | relative_url }}">
           <h4
-            class="f3 mt0 mb2 sans-serif normal accent link underline-hover lh-title"
+            class="f3 mt0 mb2 sans-serif normal accent link lh-title"
           >
             {{ opening.title }}
           </h4>

--- a/_includes/sections/navigation.html
+++ b/_includes/sections/navigation.html
@@ -1,4 +1,4 @@
-<a class="f4 f3-ns accent link underline-hover db dn-l" href="#" aria-label="Close menu">Close menu</a>
+<a class="f4 f3-ns accent no-underline underline-hover db dn-l" href="#" aria-label="Close menu">Close menu</a>
 <h2 id="menu-heading" class="clip">Main navigation menu</h2>
 <ul aria-labelledby="menu-heading" class="list mv4 mv0-l pa0 f3 ml3-l pl3-l flex flex-column flex-row-l items-end" role="menubar">
   {% assign pages = site.pages | sort: 'order' %}
@@ -8,7 +8,7 @@
     {% if page.menu_title %}
       {% if page.menu_title == "Work" %}
         <li class="dropdown-container relative" role="none">
-          <a class="pa3 pv0-l db link underline-hover hover-accent mid-gray {% if current_page_slug[1] == 'work' %}accent underline{% endif %}" 
+          <a class="pa3 pv0-l db no-underline underline-hover hover-accent mid-gray {% if current_page_slug[1] == 'work' %}accent underline{% endif %}" 
              href="{{ page.url | relative_url }}" 
              role="menuitem"
              aria-haspopup="true"
@@ -19,7 +19,7 @@
               role="menu" 
               aria-label="Work submenu">
             <li role="none" class="dn-l">
-              <a class="pa3 pl0 db link underline-hover hover-accent mid-gray" 
+              <a class="pa3 pl0 db no-underline underline-hover hover-accent mid-gray" 
                  href="{{ page.url | relative_url }}"
                  role="menuitem">
                 View all work
@@ -28,7 +28,7 @@
             {%- for page in pages -%}
               {% if page.work_menu_title %}
                 <li role="none">
-                  <a class="ml4-nl pa2 pa3-l f4 f3-l lb db link underline-hover hover-accent mid-gray {% if current_page contains page.url %}accent underline{% endif %}" 
+                  <a class="ml4-nl pa2 pa3-l f4 f3-l lb db no-underline underline-hover hover-accent mid-gray {% if current_page contains page.url %}accent underline{% endif %}" 
                      href="{{ page.url | relative_url }}"
                      role="menuitem">
                     {{ page.title }}
@@ -40,7 +40,7 @@
         </li>
       {% else %}
         <li role="none">
-          <a class="pa3 pv0-l db link underline-hover hover-accent mid-gray {% if page.url contains current_page_slug[1] or page.url == current_page %}accent underline{% endif %}" 
+          <a class="pa3 pv0-l db no-underline underline-hover hover-accent mid-gray {% if page.url contains current_page_slug[1] or page.url == current_page %}accent underline{% endif %}" 
              href="{{ page.url | relative_url }}"
              role="menuitem"
              {% if page.url == current_page %}aria-current="page"{% endif %}>
@@ -52,13 +52,13 @@
   {%- endfor -%}
   {% if site.openings != empty %}
     <li role="none">
-      <a class="pa3 pv0-l db link underline-hover hover-accent mid-gray" 
+      <a class="pa3 pv0-l db no-underline underline-hover hover-accent mid-gray" 
          href="/people#openings"
          role="menuitem">Openings</a>
     </li>
   {% endif %}
 </ul>
-<p class="gray b sans-serif db dn-l"><span class="dib mr2">Email</span><a class="accent link underline-hover dib sans dn-l normal" href="mailto:{{ site.email-hidden }}">{{ site.email }}</a></p>
+<p class="gray b sans-serif db dn-l"><span class="dib mr2">Email</span><a class="accent no-underline underline-hover dib sans dn-l normal" href="mailto:{{ site.email-hidden }}">{{ site.email }}</a></p>
 
 <!-- CSS for dropdown functionality -->
 <style>

--- a/_includes/sections/project.html
+++ b/_includes/sections/project.html
@@ -10,7 +10,7 @@
     <h2 class="f3 sans-serif accent">{{ project.title }}</h2>
     <div class="f4">
       {% if project.dripline_post %}
-        <a href='/dripline/{{ project.dripline_post }}' class='accent link underline-hover mb4'>Read the Dripline post</a>
+        <a href='/dripline/{{ project.dripline_post }}' class='accent link mb4'>Read the Dripline post</a>
       {% endif %}
     </div>
     <div class="mb2 f4 lh-copy" id="{{ project.title }}">
@@ -19,7 +19,7 @@
       </div>
       {% if project.content contains "<!-- more -->" %}
         <div class="mt2">
-          <span class="mv0 link accent pointer underline-hover w-fit" tabindex="0" role="button" aria-expanded="false" onclick="expandContent(this)" onkeydown="handleKeydown(event, this)">
+          <span class="mv0 link accent pointer w-fit" tabindex="0" role="button" aria-expanded="false" onclick="expandContent(this)" onkeydown="handleKeydown(event, this)">
             [read more]
           </span>
         </div>

--- a/_includes/sections/team-bios.html
+++ b/_includes/sections/team-bios.html
@@ -23,7 +23,7 @@
         {{ person.excerpt | markdownify }}
       </div>
       {% unless person.excerpt == person.content %}
-        <p class="mv0 link accent pointer underline-hover w-fit"
+        <p class="mv0 link accent pointer w-fit"
            tabindex="0"
            role="button"
            aria-expanded="false"

--- a/_includes/sections/what-we-do.html
+++ b/_includes/sections/what-we-do.html
@@ -3,7 +3,7 @@
       <h2>What we do</h2>
     <p class="lh-copy f3 measure mt0">
       We’re a diverse team of expert creatives, builders, and organizers who collaborate closely with clients to advance their missions through tech. Read more about
-      <a class="accent link underline-hover" href="/work/">our work</a>  across Hypha's three practice areas.
+      <a class="accent link" href="/work/">our work</a>  across Hypha's three practice areas.
     </p>
   </div>
 </div>
@@ -11,22 +11,15 @@
   {% assign sorted_elements = page.what_we_do | sort: 'order' %}
   {% for element in sorted_elements %}
     <div class="w-30-l measure flex-column justify-left items-left tl pr4">
-      {% if element.slug %}
-        <a href="/{{ element.slug }}/" class="underline-hover">
-      {% endif %}
       <h2 class="f2 accent mb1">
         {{ element.title }}
       </h2>
-      {% if element.slug %}
-        </a>
-      {% endif %}
       <p class="pb3 f3 lh-copy">
         {{ element.description }}
       
         {% if element.slug %}
-          <a href="/{{ element.slug }}/" class="accent link underline-hover">Read more</a>.
+          <a href="/{{ element.slug }}/" class="accent link">Read more</a>.
         {% endif %}
-
       </p>
     </div>
   {% endfor %}

--- a/_includes/sections/work-with-us.html
+++ b/_includes/sections/work-with-us.html
@@ -10,7 +10,7 @@
       <dt class="mb3 mt0 f3"><strong>Telephone</strong></dt>
       <dd class="ml0">
         <a
-          class="accent f3 link underline-hover"
+          class="accent f3 link"
           href="tel:{{ site.phone | | remove: ' ' | remove: '-' }}"
           >{{ site.phone }}</a
         >
@@ -20,7 +20,7 @@
       <dt class="mb3 mt0 f3"><strong>Email</strong></dt>
       <dd class="ml0">
         <a
-          class="accent f3 link underline-hover"
+          class="accent f3 link"
           href="mailto:{{ site.email-hidden }}"
           >{{ site.email }}</a
         >

--- a/_layouts/cosmos/post.html
+++ b/_layouts/cosmos/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <section class="mt4 ph3 ph5-l">
   <div class="mb4 mt5">
-    <a class="sans-serif link underline-hover accent" title="See more blog posts" href="{% link cosmos.html %}">← Back
+    <a class="sans-serif link accent" title="See more blog posts" href="{% link cosmos.html %}">← Back
       to Hypha Does Cosmos</a>
   </div>
   <header class="mt5 mb6 mw8 center">
@@ -13,7 +13,7 @@ layout: default
     <p><strong>{{ page.author | upcase }}</strong></p>
     {% endif %}
     <h3 class="gray f6 f5-l lh-solid mt0">{{ page.date | date: site.date_format }}</h3>
-    <div class="lh-copy mw7 mb4 links-accent links-underline-hover">
+    <div class="lh-copy mw7 mb4 links-accent">
       {% if page.acknowledgement != "" or page.acknowledgement != nil %}
       <p><em>{{ page.acknowledgement | markdownify }}</em></p>
       {% endif %}
@@ -23,7 +23,7 @@ layout: default
     {{ content }}
   </article>
   <footer class="mt5 bt bw2 b--light-gray">
-    <p><a class="link accent underline-hover" href="{% link cosmos.html %}">← <span class="gray">See more blog
+    <p><a class="link accent" href="{% link cosmos.html %}">← <span class="gray">See more blog
           posts</span></a></p>
   </footer>
 </section>

--- a/_layouts/dripline/post.html
+++ b/_layouts/dripline/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <section class="mt4 ph3 ph5-l">
   <div class="mb4 mt5">
-    <a class="sans-serif link underline-hover accent" title="Return to Dripline" href="{% link dripline.html %}">← Dripline</a>
+    <a class="sans-serif link accent" title="Return to Dripline" href="{% link dripline.html %}">← Dripline</a>
   </div>
   <header class="mt5 mb6 mw8 center">
     <h1 class="f1-ns f2 sans-serif lh-solid mb3 mt0-l">{{ page.title }}</h1>
@@ -12,7 +12,7 @@ layout: default
     <p><strong>{{ page.author | upcase }}</strong></p>
     {% endif %}
     <h3 class="gray f6 f5-l lh-solid mt0">{{ page.date | date: site.date_format }}</h3>
-    <div class="lh-copy mw7 mb4 links-accent links-underline-hover">
+    <div class="lh-copy mw7 mb4 links-accent">
       {% if page.acknowledgement != "" or page.acknowledgement != nil %}
       <div><em>{{ page.acknowledgement | markdownify }}</em></div>
       {% endif %}
@@ -29,6 +29,6 @@ layout: default
     {% include activity_pub/interactions.html activity=page.activity profile=site.actor %}
   {% endif %}
   <footer class="mt5 bt bw2 b--light-gray">
-    <p><a class="link accent underline-hover" href="{% link dripline.html %}">← <span class="gray">Return to Dripline</span></a></p>
+    <p><a class="link accent" href="{% link dripline.html %}">← <span class="gray">Return to Dripline</span></a></p>
   </footer>
 </section>

--- a/_layouts/openings/opening.html
+++ b/_layouts/openings/opening.html
@@ -4,13 +4,13 @@ layout: default
 
 <section id="opening" class="mt4 ph3 ph5-l ">
   <div class="mb4">
-    <a class="sans-serif link underline-hover accent" title="Return to Openings" href="/people#openings">← Openings</a>
+    <a class="sans-serif link accent" title="Return to Openings" href="/people#openings">← Openings</a>
   </div>
   <header class="mb4">
     <h1 class="f1 f-subheadline-l sans-serif lh-solid mb3 mt0-l">{{ page.title }}</h1>
   </header>
-  <div class="lh-copy mw7 links-accent links-underline-hover">{{ content }}</div>
+  <div class="lh-copy mw7 links-accent">{{ content }}</div>
   <footer class="mt5 bt bw2 b--light-gray">
-    <p><a class="sans-serif link underline-hover accent" title="Return to Openings" href="/people#openings">Openings</a></p>
+    <p><a class="sans-serif link accent" title="Return to Openings" href="/people#openings">Openings</a></p>
   </footer>
 </section>

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -55,9 +55,7 @@ mark {
   color: $accent-color;
 }
 
-.links-underline-hover a:hover {
-  text-decoration: none;
-}
+
 
 // Menu interaction
 
@@ -204,14 +202,15 @@ p {
 a {
   @extend .accent;
   @extend .link;
-  @extend .underline-hover;
+  text-decoration: underline;
 }
 
-a.no-underline, 
-a.no-underline:hover,
-a.no-underline:focus {
+a:hover,
+a:focus {
   text-decoration: none;
 }
+
+// Removed no-underline class as it's no longer needed
 
 #what_we_do div.accent:hover,
 #values div.accent:hover {

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -210,7 +210,6 @@ a:focus {
   text-decoration: none;
 }
 
-// Removed no-underline class as it's no longer needed
 
 #what_we_do div.accent:hover,
 #values div.accent:hover {

--- a/_sass/tachyons-sass/scss/_links.scss
+++ b/_sass/tachyons-sass/scss/_links.scss
@@ -13,7 +13,7 @@
 */
 
 .link {
-  text-decoration: none;
+  text-decoration: underline;
   transition: color .15s ease-in;
 }
 

--- a/cosmos.html
+++ b/cosmos.html
@@ -27,7 +27,7 @@ permalink: '/doescosmos/'
         {%- assign date_format = site.date_format -%} {%- for post in posts -%}
         <div class="bg-white measure pv3 pr6-l pl0-l pr0-s pl0-s center mb4 db">
             <a class="no-underline" href="{{ post.url | relative_url }}">
-                <h3 class="f3 mt0 mb2 sans-serif normal accent link underline-hover lh-title">
+                <h3 class="f3 mt0 mb2 sans-serif normal accent link lh-title">
                     {{ post.title | escape }}
                 </h3>
             </a>

--- a/dripline.html
+++ b/dripline.html
@@ -29,7 +29,7 @@ order: 4
               <a
                 href="https://permacultureprinciples.com/permaculture-principles/_11/"
                 target="_blank"
-                class="accent link underline-hover"
+                class="accent link"
                 rel="noopener"
                 >interface</a
               >
@@ -46,7 +46,7 @@ order: 4
     <div class="bg-white measure pv3 pr6-l pl0-l pr0-s pl0-s center mb4 db w-fill-available">
       <a class="no-underline" href="{{ post.url | relative_url }}">
         <h3
-          class="f3 mt0 mb2 sans-serif normal accent link underline-hover lh-title"
+          class="f3 mt0 mb2 sans-serif normal accent link lh-title"
         >
           {{ post.title | escape }}
         </h3>

--- a/work.html
+++ b/work.html
@@ -36,7 +36,7 @@ order: 3
     {% if matching_practice_area.size > 0 %}
       <div class="flex flex-column mb3">
         {% if practice.slug %}
-          <a href="/{{ practice.slug }}/" class="underline-hover">
+          <a href="/{{ practice.slug }}/" class="">
         {% endif %}
         <h2 class="f2 sans-serif accent mb3 mt4">
           {{ practice.title }}
@@ -54,7 +54,7 @@ order: 3
             </p>
           {% endif %}
           <p class="measure-wide mt2 mb2 f3">
-            <a href="/{{ practice.slug }}/" class="accent link underline-hover">Read more</a>
+            <a href="/{{ practice.slug }}/" class="accent link">Read more</a>
           </p>
           {% endif %}
       </div>


### PR DESCRIPTION
For web accessibility, links should be underlined -> visually distinct from body text to help users.

this pr:
- sets links as underlined by default
- removes `underline-hover` on links
- link hover now removes underline
- removes links from headers in `what-we-do`
- `no-underline` class was added to menu items to maintain style
 

see deployment preview 