### PR TITLE
Create Dripline component for the homepage

### DIFF
--- a/_data/activity_pub.yml
+++ b/_data/activity_pub.yml
@@ -154,6 +154,6 @@ notifications:
     action: done
     id: https://hypha.coop/dripline/hypha-loves-dasl-the-testing-suite.jsonld
     created_at: 1753880183
-actor_url: https://hypha.coop/about.jsonld
-actor: "@dripline@hypha.coop"
-public_key_url: https://hypha.coop/about.jsonld#main-key
+actor_url: https://staging.hypha.coop/about.jsonld
+actor: "@dripline@staging.hypha.coop"
+public_key_url: https://staging.hypha.coop/about.jsonld#main-key

--- a/_includes/sections/about-dripline.html
+++ b/_includes/sections/about-dripline.html
@@ -1,0 +1,10 @@
+<h2>Our publishing interface</h2>
+<div class="flex-ns justify-start mt0">
+  <div class="measure-wide-l measure-m mr5-l">
+    <p class="measure f3 lh-copy mt0">
+      Read essays, interviews, and reflections on 
+        <a href="/dripline" class="accent link">
+          Dripline</a>, a place where we share our work and the futures we're building together.
+    </p>
+  </div>
+</div>

--- a/_includes/sections/newsletter.html
+++ b/_includes/sections/newsletter.html
@@ -1,18 +1,18 @@
 <div class="flex-l items-center mv2">
-    <div class="w-100-l mt4 mt5-l cover">
-        <h2 class="f1 f-subheadline-l sans-serif accent">
+    <div class="w-100-l mt5 cover">
+        <h2>
             Beyond the Dripline
         </h2>
-        <div class="flex-l items-center mt3 mt4-l">
-            <div class="w-100 w-two-thirds-l pr4-l">
-                <h3 class="f3 f3-l normal lh-solid measure  sans-serif">
+        <div class="flex-l mt3 mt4-l justify-between items-end lh-copy">
+            <div class="w-100 measure-wide-l measure-m pr4-l mr5-l">
+                <p class="f3 f3-l normal lh-copy measure sans-serif">
                     Our 
                     <a href="https://newsletter.hypha.coop/" target="_blank" rel="noopener">
                         newsletter</a>
-                     where we cultivate stories about co-operative technologies
-                    </h3>
+                     where we cultivate stories about co-operative technologies.
+                </p>
             </div>
-            <div class="w-100 w-third-l mt3 mt0-l">
+            <div class="w-100 w-third-l mt3 mb4 mt0-l mr4-l">
                 <div style="min-height: 58px;max-width: 440px;margin: 0;width: 100%">
                     <script src="https://cdn.jsdelivr.net/ghost/signup-form@~0.2/umd/signup-form.min.js"
                         data-button-color="#9900FC" data-button-text-color="#FFFFFF"

--- a/_includes/sections/our-services.html
+++ b/_includes/sections/our-services.html
@@ -1,4 +1,4 @@
-<div class="flex justify-start lh-copy f3 mt6-ns mt5 mb4">
+<div class="flex justify-start lh-copy f3 mt5 mb4">
   <div class="mr3">
     <h2>Our services</h2>
   <p class="lh-copy f3 measure mt0">

--- a/_includes/sections/our-values.html
+++ b/_includes/sections/our-values.html
@@ -1,4 +1,4 @@
-<div class="measure-m mt6-ns mt5 mb4 mr5-l">
+<div class="measure-m mt5 mb4 mr5-l">
   <h2 class="f1 f-subheadline-l sans-serif mt0 accent">Technology you can believe in</h2>
   </div>
 

--- a/_includes/sections/what-we-do.html
+++ b/_includes/sections/what-we-do.html
@@ -1,4 +1,4 @@
-<div class="flex justify-start lh-copy f3 mt6 mb4">
+<div class="flex justify-start lh-copy f3 mt5 mb4">
   <div class="mr3">
       <h2>What we do</h2>
     <p class="lh-copy f3 measure mt0">

--- a/_includes/sections/who-we-are.html
+++ b/_includes/sections/who-we-are.html
@@ -1,4 +1,4 @@
-<div class="flex justify-between flex-nowrap-ns flex-wrap  mt6-ns mt5 mb4 mr5-l">
+<div class="flex justify-between flex-nowrap-ns flex-wrap mt5 mb5 mr5-l">
     <div class="flex flex-column measure-wide-l measure-m">
       <h2>
         Co-operation is our DNA

--- a/_includes/sections/work-with-us.html
+++ b/_includes/sections/work-with-us.html
@@ -1,4 +1,4 @@
-<div class="flex-l mt6-ns mt5 mb6-ns mb4">
+<div class="flex-l mt5 mb6-ns mb4">
   <div class="w-75-l">
     <h2 class="f1 f-subheadline-l sans-serif accent">Work with us</h2>
 

--- a/index.html
+++ b/index.html
@@ -29,5 +29,6 @@ our_services:
 {%- include sections.html path="our-values.html" class="" -%}
 {%- include sections.html path="our-services.html" class="" -%}
 {%- include sections.html path="who-we-are.html" class="" -%}
+{%- include sections.html path="about-dripline.html" class="" -%}
 {%- include sections.html path="newsletter.html" class="mv5" -%}
 {%- include sections.html path="work-with-us.html" class="mv5" -%}

--- a/index.html
+++ b/index.html
@@ -30,5 +30,5 @@ our_services:
 {%- include sections.html path="our-services.html" class="" -%}
 {%- include sections.html path="who-we-are.html" class="" -%}
 {%- include sections.html path="about-dripline.html" class="" -%}
-{%- include sections.html path="newsletter.html" class="mv5" -%}
-{%- include sections.html path="work-with-us.html" class="mv5" -%}
+{%- include sections.html path="newsletter.html" class="" -%}
+{%- include sections.html path="work-with-us.html" class="" -%}


### PR DESCRIPTION
After adding the subscribe button on the homepage, I realized we could also add a description of Dripline.

This PR creates a new dripline component that can be added to the homepage. It briefly describes what is Dripline and links to it. It is placed above the newsletter section. This also includes some adjustments to each sectoin's margins, improving the overall layout of the homepage.

I think this creates a nice flow.

- Read about the co-op
- Read about Dripline
- Beyond the Dripline -> Subscribe!

