### PR TITLE
make dripline posts narrower + matching header width

### DIFF
--- a/_layouts/dripline/post.html
+++ b/_layouts/dripline/post.html
@@ -18,7 +18,7 @@ layout: default
       {% endif %}
     </div>
   </header>
-  <article id="dripline" class="mw8 center">
+  <article id="dripline" class="read-width center">
     {{ content }}
   </article>
   {% if page.activity.inReplyTo %}

--- a/_layouts/dripline/post.html
+++ b/_layouts/dripline/post.html
@@ -6,7 +6,7 @@ layout: default
   <div class="mb4 mt5">
     <a class="sans-serif link accent" title="Return to Dripline" href="{% link dripline.html %}">← Dripline</a>
   </div>
-  <header class="mt5 mb6 mw8 center">
+  <header class="read-width mt5 mb6 center">
     <h1 class="f1-ns f2 sans-serif lh-solid mb3 mt0-l">{{ page.title }}</h1>
     {% if page.author != "" or page.author != nil %}
     <p><strong>{{ page.author | upcase }}</strong></p>
@@ -22,11 +22,11 @@ layout: default
     {{ content }}
   </article>
   {% if page.activity.inReplyTo %}
-    {% include activity_pub/replying_to.html activity=page.activity.inReplyTo %}
+  {% include activity_pub/replying_to.html activity=page.activity.inReplyTo %}
   {% endif %}
 
   {% if page.activity %}
-    {% include activity_pub/interactions.html activity=page.activity profile=site.actor %}
+  {% include activity_pub/interactions.html activity=page.activity profile=site.actor %}
   {% endif %}
   {%- include sections.html path="newsletter.html" class="mt5" -%}
   <footer class="mt5 bt bw2 b--light-gray">

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -227,5 +227,5 @@ a:focus {
   // }
 
 .read-width {
-  width: 70ch
+  max-width: 70ch
 }

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -225,3 +225,7 @@ a:focus {
 // @media #{$breakpoint-small} {
   // .flex-wrap-s { flex-wrap: wrap;}
   // }
+
+.read-width {
+  width: 70ch
+}

--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -14,9 +14,6 @@
     font-family: $code;
     font-size: 0.9em;
     line-height: 1.5;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
- Same as #504 but with matching header width.

My original reaction to #504 was to match the post's width with the header's width.

Looking for feedback on the team's preference.

See deployment preview link below for comparison:

- [Matching width preview](https://deploy-preview-506--hyphacoop.netlify.app/) (this PR)
- [Narrow width only applied to the post's content preview](https://deploy-preview-504--hyphacoop.netlify.app/) (#504)