### PR TITLE
normalize layout margins

### DIFF
--- a/_includes/sections/about.html
+++ b/_includes/sections/about.html
@@ -1,14 +1,14 @@
-<div class="flex-l items-center mv2">
+<div class="flex-l items-center">
   <div class="w-100-l mt5 mt6-ns cover">
     <h2 class="w-90 w-70-ns fw4">
       Resilient digital systems. Built for the future we need.
     </h2>
-    <div class="measure-wide">
-      <p class="f3 lh-copy mt0">
+    <div>
+      <p class="f3 lh-copy mt0 measure-wide">
         Reality is fragmenting. Generative AI is making it harder to know what's
         real, eroding the shared trust we need to function as a society.
       </p>
-      <p class="f3 lh-copy mt0">
+      <p class="f3 lh-copy mt0 measure-wide">
         At the same time, Big Tech platforms are tightening their grip. The
         systems we use daily to manage our social and economic lives are locking
         us in and extracting value without giving back.
@@ -16,11 +16,11 @@
       <h2 class="f2 fw6 mt5 mb3">
         Hypha operates at the intersection of these challenges.
       </h2>
-      <p class="f3 lh-copy mt0">
+      <p class="f3 lh-copy mt0 measure-wide">
         We build infrastructure that restores information integrity, enables
         verifiable computation, and unlocks new economic models.
       </p>
-      <p class="f3 lh-copy mt0">
+      <p class="f3 lh-copy mt0 measure-wide">
         Work with us to escape the web of extraction and build a web of
         sovereignty and trust.
       </p>

--- a/_includes/sections/case-studies.html
+++ b/_includes/sections/case-studies.html
@@ -1,5 +1,5 @@
-<div class="measure-wide mt5 mb4 mr5-l">
-  <h2 class="f2 fw6 mt0 mb4">We are an R&D partner for leaders in finance, culture, and technology.</h2>
+<div class="mt4 mt5-ns mb4 mr5-l">
+  <h2 class="f2 fw6 mt0 mb4 measure-wide">We are an R&D partner for leaders in finance, culture, and technology.</h2>
 </div>
 
 <div class="flex flex-wrap justify-between mb5">

--- a/_includes/sections/footer.html
+++ b/_includes/sections/footer.html
@@ -1,28 +1,28 @@
 <footer role="contentinfo">
-  <p class="f3 f4-l fw7 lh-copy dark-gray">{{ site.footer }}</p>
-  <div class="flex-l items-baseline">
-    <div class="w-100 w-50-l pr5">
+
+  <div class="flex-l items-start">
+    <div class="w-100 w-50-l pr4-l">
       <nav aria-label="Social media links">
         <ul class="list pl0 flex flex-wrap f5 f4-l items-center">
           <li class="pr3 pr4-ns mb3"><a href="{{ site.github }}" class="accent link" target="_blank"
               rel="noopener" aria-label="Visit our GitHub profile">
-              <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/github_logo.svg" alt="GitHub">
+              <img class="w2-5 h2-5 grow-large" src="/assets/images/logos/footer/github_logo.svg" alt="GitHub">
             </a></li>
           <li class="pr3 pr4-ns mb3"><a href="{{ site.linkedin }}" class="accent link" target="_blank"
               rel="noopener" data-proofer-ignore aria-label="Visit our LinkedIn profile">
-              <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/linkedin_logo.svg" alt="LinkedIn">
+              <img class="w2-5 h2-5 grow-large" src="/assets/images/logos/footer/linkedin_logo.svg" alt="LinkedIn">
             </a></li>
           <li class="pr3 pr4-ns mb3"><a href="{{ site.bluesky }}" class="accent link" target="_blank"
               rel="noopener" data-proofer-ignore aria-label="Visit our Bluesky profile">
-              <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/bluesky_logo.svg" alt="Bluesky">
+              <img class="w2-5 h2-5 grow-large" src="/assets/images/logos/footer/bluesky_logo.svg" alt="Bluesky">
             </a></li>
           <li class="pr3 pr4-ns mb3"><a href="{{ site.mastodon }}" class="accent link" target="_blank"
               rel="noopener me" aria-label="Visit our Mastodon profile">
-              <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/mastodon_logo.svg" alt="Mastodon">
+              <img class="w2-5 h2-5 grow-large" src="/assets/images/logos/footer/mastodon_logo.svg" alt="Mastodon">
             </a></li>
           <li class="pr3 pr4-ns mb3"><a href="{{ site.url }}{{ site.rss }}" class="accent link"
               target="_blank" rel="noopener" aria-label="Subscribe to our RSS feed">
-              <img class="w2 h2 w2-5-l h2-5-l grow-large" src="/assets/images/logos/footer/rss_logo.svg" alt="RSS">
+              <img class="w2-5 h2-5 grow-large" src="/assets/images/logos/footer/rss_logo.svg" alt="RSS">
             </a></li>
         </ul>
       </nav>
@@ -60,7 +60,7 @@
     </div>
     <div class="w-100 w-50-l">
       <section aria-labelledby="land-acknowledgement">
-        <h3 id="land-acknowledgement" class="f4 normal"><span class="accent">⚑</span> Hypha is rooted in Tkaronto (Toronto), Canada.</h3>
+        <h3 id="land-acknowledgement" class="f4 normal mv4"><span class="accent">⚑</span> Hypha is rooted in Tkaronto (Toronto), Canada.</h3>
 
         <h4 class="f5 measure normal lh-copy gray">
           Hypha acknowledges the sacred land we work on is the territory of many nations and was the subject of the Dish
@@ -68,6 +68,7 @@
           Lakes. Today it is still home to many First Nations, Inuit, and Métis peoples from across Turtle Island.
         </h4>
       </section>
+      <p class="f3 f4-l fw7 lh-copy dark-gray">{{ site.footer }}</p>
     </div>
   </div>
 </footer>

--- a/_includes/sections/newsletter.html
+++ b/_includes/sections/newsletter.html
@@ -1,8 +1,6 @@
-<div class="flex-l items-center mv2">
+<div class="flex-l items-center mv2 newsletter-section">
     <div class="w-100-l mt4 mt5-l cover">
-        <h2 class="f1 f-subheadline-l sans-serif accent">
-            Beyond the Dripline
-        </h2>
+        <h2>Beyond the Dripline</h2>
         <div class="flex-l items-center mt3 mt4-l">
             <div class="w-100 w-two-thirds-l pr4-l">
                 <h3 class="f3 f3-l normal lh-solid measure  sans-serif">

--- a/_includes/sections/newsletter.html
+++ b/_includes/sections/newsletter.html
@@ -1,5 +1,5 @@
-<div class="flex-l items-center mv2 newsletter-section">
-    <div class="w-100-l mt4 mt5-l cover">
+<div class="flex-l items-center mb5 mb6-ns mt5 mt6-ns newsletter-section">
+    <div class="w-100-l cover">
         <h2>Beyond the Dripline</h2>
         <div class="flex-l items-center mt3 mt4-l">
             <div class="w-100 w-two-thirds-l pr4-l">

--- a/_includes/sections/techniques.html
+++ b/_includes/sections/techniques.html
@@ -1,6 +1,6 @@
 <div class="flex justify-start lh-copy mt6-ns mt5 mb4">
   <div class="mr3">
-    <h2 class="f2 fw6 mt0 mb3">Our toolkit</h2>
+    <h2>Our toolkit</h2>
     <p class="lh-copy f3 measure-wide mt0">
       Trust isn't a technical challenge: it's a human problem. We build digital systems people can rely on through community input, democratic processes, and shared ownership. But making those human agreements work at internet scale requires expert technical infrastructure. We specialize in:
     </p>

--- a/_includes/sections/who-we-are.html
+++ b/_includes/sections/who-we-are.html
@@ -1,7 +1,7 @@
-<div class="flex justify-between flex-nowrap-ns flex-wrap mt6-ns mt5 mb4 mr5-l">
-    <div class="flex flex-column measure-wide-l measure-m">
+<div class="flex justify-between flex-nowrap-ns flex-wrap mt6-ns mt5 mb4">
+    <div class="flex flex-column justify-center measure-wide-l measure-m pr4-l">
       <h2>Our team</h2>
-      <p class="f3 fw6 mt0 mb3">Worker-owned. Employee-controlled.</p>
+      <p class="f3 fw6 mt0 mb3 accent">Worker-owned. Employee-controlled.</p>
       <p class="f3 lh-copy mt0">
         We're a cooperative because we believe it changes the equation: long-term relationships over quick wins, quality over moving fast and breaking things. We're driven by collaboration and community, and our shared values are reflected in the approach we bring to each project.
       </p>
@@ -10,7 +10,7 @@
       </p>
     </div>
     <div class="w-100 w-50-ns">
-        <img class="mw-100" src="/assets/images/block2.png" alt="mushrooms growing out of a computer chip"/>
+        <img class="mw-100" src="/assets/images/block2.png" alt="mushrooms growing out of a computer chip" loading="lazy"/>
     </div>
 </div>
 

--- a/_includes/sections/work-with-us.html
+++ b/_includes/sections/work-with-us.html
@@ -1,34 +1,36 @@
-<div class="flex-l mt6-ns mt5 mb6-ns mb4">
-  <div class="w-75-l">
+<div class="flex-l mt6-ns mt5">
+  <div class="w-75-l pr4-l">
     <h2 class="f1 f-subheadline-l sans-serif accent">Work with us</h2>
 
     <p class="f3 lh-copy measure-wide mt0 mb4">
       We're looking for projects and partnerships focused on the intersection of technology and trust. If you're interested in building systems that need to be verifiable, democratic, or genuinely decentralized — or you're curious about exploring the possibilities — get in touch.
     </p>
 
-    <div class="flex flex-wrap">
-      <dl class="dib mr5 mb3">
-        <dt class="mb2 mt0 f4"><strong>Book a meeting</strong></dt>
-        <dd class="ml0">
-          <a class="accent f4 link" href="https://link.hypha.coop/hello-udit">Schedule a call</a>
-        </dd>
-      </dl>
-      <dl class="dib mr5 mb3">
-        <dt class="mb2 mt0 f4"><strong>Email</strong></dt>
-        <dd class="ml0">
-          <a class="accent f4 link" href="mailto:{{ site.email-hidden }}">{{ site.email }}</a>
-        </dd>
-      </dl>
-      <dl class="dib mr5 mb3">
-        <dt class="mb2 mt0 f4"><strong>Telephone</strong></dt>
-        <dd class="ml0">
-          <a class="accent f4 link" href="tel:{{ site.phone | remove: ' ' | remove: '-' }}">{{ site.phone }}</a>
-        </dd>
-      </dl>
+    <div class="measure-wide f3">
+      <div class="flex flex-wrap">
+        <dl class="dib mr5 mb3">
+          <dt class="mb2 mt0 f4"><strong>Book a meeting</strong></dt>
+          <dd class="ml0">
+            <a class="accent f4 link" href="https://link.hypha.coop/hello-udit">Schedule a call</a>
+          </dd>
+        </dl>
+        <dl class="dib mr5 mb3">
+          <dt class="mb2 mt0 f4"><strong>Email</strong></dt>
+          <dd class="ml0">
+            <a class="accent f4 link" href="mailto:{{ site.email-hidden }}">{{ site.email }}</a>
+          </dd>
+        </dl>
+        <dl class="dib mr5 mb3">
+          <dt class="mb2 mt0 f4"><strong>Telephone</strong></dt>
+          <dd class="ml0">
+            <a class="accent f4 link" href="tel:{{ site.phone | remove: ' ' | remove: '-' }}">{{ site.phone }}</a>
+          </dd>
+        </dl>
+      </div>
     </div>
   </div>
   <div class="contain w-25-l mt5">
-    <img class="mw-50 di-l dn" alt="server" src="/assets/images/block3.png">
-    <img alt="server" src="/assets/images/block3.png">
+    <img class="mw-50 di-l dn" alt="server" src="/assets/images/block3.png" loading="lazy">
+    <img alt="server" src="/assets/images/block3.png" loading="lazy">
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
       {{ content }}
     </main>
 
-    {%- include sections.html tag="footer" path="footer.html" class="mw9 center mv5" role="contentinfo" -%}
+    {%- include sections.html tag="footer" path="footer.html" class="mw9 center mt5 mt6-ns" role="contentinfo" -%}
 
   </body>
 </html>

--- a/_layouts/practice_area.html
+++ b/_layouts/practice_area.html
@@ -69,7 +69,7 @@
         </div>
       </section>
       </main>
-      {%- include sections.html tag="footer" path="footer.html" class="mw9 center mv5" -%}
+      {%- include sections.html tag="footer" path="footer.html" class="mw9 center mt5" -%}
     </body>
 </html>
       

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -197,8 +197,14 @@ h2 {
   // border: 1px solid black;
 }
 
-h3 {
-  @extend .accent;
+// Homepage h3 elements should be purple (accent color)
+.root-and-lines h3 {
+  color: $accent-color;
+}
+
+// Newsletter h3 on homepage should be black
+.root-and-lines .newsletter-section h3 {
+  color: $black;
 }
 
 p {

--- a/_sass/_hypha.scss
+++ b/_sass/_hypha.scss
@@ -197,6 +197,13 @@ h2 {
   // border: 1px solid black;
 }
 
+h3 {
+  @extend .f3;
+  @extend .f2-l;
+  @extend .fw6;
+  @extend .mb3;
+}
+
 // Homepage h3 elements should be purple (accent color)
 .root-and-lines h3 {
   color: $accent-color;

--- a/index.html
+++ b/index.html
@@ -50,5 +50,5 @@ our_services:
 {%- include sections.html path="case-studies.html" class="" -%}
 {%- include sections.html path="techniques.html" class="" -%}
 {%- include sections.html path="who-we-are.html" class="" -%}
-{%- include sections.html path="work-with-us.html" class="mv5" -%}
-{%- include sections.html path="newsletter.html" class="mv5" -%}
+{%- include sections.html path="work-with-us.html" class="" -%}
+{%- include sections.html path="newsletter.html" class="" -%}


### PR DESCRIPTION
**Layout & Spacing**: 

- enforced consistent 128px (mt6-ns) vertical gaps between major sections
- tightened the "Case Studies" lead-in to 64px (mt5-ns) for better flow.

**Footer**: 
- refactored into a split-column flex layout; aligned corporate info to the bottom-right.

**Typography**: 
- standardizes global h3 styles.

**Other improvements**: 

- Removed ad-hoc margin classes from `index.html`
- added `loading="lazy"` to images.