### PR TITLE
Automate social card generation for new posts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,15 +26,54 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       # Standard checkout for non-PR events
       - name: Checkout repo
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Install Brotli development headers (Fix for ruby-brs gem)
       - name: Install Brotli dependencies
         run: sudo apt-get update && sudo apt-get install -y libbrotli-dev
+
+      - name: Install social card dependencies
+        if: github.event_name == 'push'
+        run: sudo apt-get install -y imagemagick webp
+
+      - name: Generate social cards for new posts
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+
+          BEFORE_SHA="${{ github.event.before }}"
+          CURRENT_SHA="${{ github.sha }}"
+          EMPTY_SHA="0000000000000000000000000000000000000000"
+
+          if [[ "$BEFORE_SHA" == "$EMPTY_SHA" ]]; then
+            mapfile -t NEW_POSTS < <(git diff-tree --no-commit-id --name-status -r "$CURRENT_SHA" -- "_posts/*.md" | awk '$1=="A"{print $2}')
+          else
+            mapfile -t NEW_POSTS < <(git diff --name-status "$BEFORE_SHA" "$CURRENT_SHA" -- "_posts/*.md" | awk '$1=="A"{print $2}')
+          fi
+
+          if [[ "${#NEW_POSTS[@]}" -eq 0 ]]; then
+            echo "No newly added posts found. Skipping social card generation."
+            exit 0
+          fi
+
+          printf 'Generating social cards for:\n%s\n' "${NEW_POSTS[@]}"
+          ./social_cards_automation_scripts/createImagesFromPosts.sh "${NEW_POSTS[@]}"
+
+      - name: Commit generated social cards
+        if: github.event_name == 'push'
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: '_posts,assets/images/social/dripline'
+          default_author: github_actions
+          message: 'Generate social cards for new posts'
+          fetch: true
 
       # Install Sequoia (AT Protocol / Standard.site)
       # Only on push to master 
@@ -128,5 +167,4 @@ jobs:
           default_author: github_actions
           message: 'Commit ActivityPub and Sequoia data'
           fetch: true
-
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Generate social cards for new posts
         if: github.event_name == 'push'
+        continue-on-error: true
         run: |
           set -euo pipefail
 
@@ -53,7 +54,7 @@ jobs:
           EMPTY_SHA="0000000000000000000000000000000000000000"
 
           if [[ "$BEFORE_SHA" == "$EMPTY_SHA" ]]; then
-            mapfile -t NEW_POSTS < <(git diff-tree --no-commit-id --name-status -r "$CURRENT_SHA" -- "_posts/*.md" | awk -F'\t' '$1=="A"{print $2}')
+            mapfile -t NEW_POSTS < <(git log --diff-filter=A --name-only --pretty="" origin/master.."$CURRENT_SHA" -- "_posts/*.md" | sort -u)
           else
             mapfile -t NEW_POSTS < <(git diff --name-status "$BEFORE_SHA" "$CURRENT_SHA" -- "_posts/*.md" | awk -F'\t' '$1=="A"{print $2}')
           fi
@@ -68,6 +69,7 @@ jobs:
 
       - name: Commit generated social cards
         if: github.event_name == 'push'
+        continue-on-error: true
         uses: EndBug/add-and-commit@v9
         with:
           add: '_posts,assets/images/social/dripline'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,9 @@ jobs:
           EMPTY_SHA="0000000000000000000000000000000000000000"
 
           if [[ "$BEFORE_SHA" == "$EMPTY_SHA" ]]; then
-            mapfile -t NEW_POSTS < <(git diff-tree --no-commit-id --name-status -r "$CURRENT_SHA" -- "_posts/*.md" | awk '$1=="A"{print $2}')
+            mapfile -t NEW_POSTS < <(git diff-tree --no-commit-id --name-status -r "$CURRENT_SHA" -- "_posts/*.md" | awk -F'\t' '$1=="A"{print $2}')
           else
-            mapfile -t NEW_POSTS < <(git diff --name-status "$BEFORE_SHA" "$CURRENT_SHA" -- "_posts/*.md" | awk '$1=="A"{print $2}')
+            mapfile -t NEW_POSTS < <(git diff --name-status "$BEFORE_SHA" "$CURRENT_SHA" -- "_posts/*.md" | awk -F'\t' '$1=="A"{print $2}')
           fi
 
           if [[ "${#NEW_POSTS[@]}" -eq 0 ]]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,12 @@ jobs:
           EMPTY_SHA="0000000000000000000000000000000000000000"
 
           if [[ "$BEFORE_SHA" == "$EMPTY_SHA" ]]; then
-            mapfile -t NEW_POSTS < <(git log --diff-filter=A --name-only --pretty="" origin/master.."$CURRENT_SHA" -- "_posts/*.md" | sort -u)
+            BASE_REF=$(jq -r '.base_ref // "refs/heads/master"' "$GITHUB_EVENT_PATH" | sed 's|refs/heads/|origin/|')
+            if git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+              mapfile -t NEW_POSTS < <(git log --diff-filter=A --name-only --pretty="" "$BASE_REF..$CURRENT_SHA" -- "_posts/*.md" | grep -v '^$' | sort -u)
+            else
+              mapfile -t NEW_POSTS < <(git log --diff-filter=A --name-only --pretty="" "$CURRENT_SHA" -- "_posts/*.md" | grep -v '^$' | sort -u)
+            fi
           else
             mapfile -t NEW_POSTS < <(git diff --name-status "$BEFORE_SHA" "$CURRENT_SHA" -- "_posts/*.md" | awk -F'\t' '$1=="A"{print $2}')
           fi

--- a/social_cards_automation_scripts/createImagesFromPosts.sh
+++ b/social_cards_automation_scripts/createImagesFromPosts.sh
@@ -1,105 +1,166 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# This script generates social cards for each markdown post file in the specified directory.
-# It uses ImageMagick to create an image with the post title, excerpt, and author.
-# The generated images are saved in a separate directory.
+# Generates social cards for provided post paths (or all posts if no args),
+# writes images to assets/images/social/dripline, and upserts `image:` frontmatter.
 
-# Ensure ImageMagick and cwebp are installed
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+POSTS_DIR="$REPO_ROOT/_posts"
+FONTS_DIR="$SCRIPT_DIR/fonts"
+IMAGES_DIR="$REPO_ROOT/assets/images/social/dripline"
+IMAGE_PREFIX="/assets/images/social/dripline"
 
-# This script assumes that the markdown files are in the root of the _posts directory
-
-# Directory where your markdown post files are stored
-POSTS_DIR="../_posts"
-
-# Directory where fonts are stored
-FONTS_DIR="fonts"
-
-# Directory where images will be saved
-IMAGES_DIR="img"
-
-# Create the images directory if it does not exist
 mkdir -p "$IMAGES_DIR"
 
-# Function to dynamically adjust text to prevent overflow
 adjust_text() {
-    local text="$1"
-    local max_length="$2"  # Max pixel width for text
-    local font_dir="$3"    # Directory for fonts
-    local font_file="$4"   # Font file name
-    local min_font_size="${5:-20}"  # Minimum font size, default is 20 if not provided
+  local text="$1"
+  local max_length="$2"
+  local font_dir="$3"
+  local font_file="$4"
+  local min_font_size="${5:-20}"
 
-    local font_size=76    # Initial font size
-    local adjusted_text="$text"
-    local temp_file="temp.png"
-    local text_width
+  local font_size=76
+  local adjusted_text="$text"
+  local temp_file
+  temp_file="$(mktemp)"
+  local text_width
 
-    # Use ImageMagick to calculate the width of the rendered text
-    while true; do
-        if ! convert -background none -fill white -font "$font_dir/$font_file" -pointsize $font_size label:"$adjusted_text" "$temp_file"; then
-            echo "Error generating image with convert command."
-            return 1
-        fi
-
-        text_width=$(identify -format "%w" "$temp_file")
-        rm -f "$temp_file"
-
-        if [[ $text_width -le $max_length ]] || [[ $font_size -le $min_font_size ]]; then
-            break
-        fi
-
-        font_size=$((font_size - 8))  # Reduce font size to make text fit
-    done
-
-    # Apply more aggressive wrapping if still necessary
-    if [[ $text_width -gt $max_length ]]; then
-        local wrap_width=$((max_length / font_size * 2))  # Dynamic wrap width based on font size
-        adjusted_text=$(echo "$adjusted_text" | fold -w "$wrap_width" -s)  # Wrap text to fit
+  while true; do
+    if ! convert -background none -fill white -font "$font_dir/$font_file" -pointsize "$font_size" label:"$adjusted_text" "$temp_file"; then
+      echo "Failed to render title text" >&2
+      rm -f "$temp_file"
+      return 1
     fi
 
-    echo "$adjusted_text"
+    text_width="$(identify -format "%w" "$temp_file")"
+
+    if [[ "$text_width" -le "$max_length" || "$font_size" -le "$min_font_size" ]]; then
+      break
+    fi
+
+    font_size=$((font_size - 8))
+  done
+
+  rm -f "$temp_file"
+
+  if [[ "$text_width" -gt "$max_length" ]]; then
+    local wrap_width=$((max_length / font_size * 2))
+    adjusted_text="$(echo "$adjusted_text" | fold -w "$wrap_width" -s)"
+  fi
+
+  echo "$adjusted_text"
 }
 
+upsert_image_frontmatter() {
+  local post_file="$1"
+  local image_path="$2"
+  local tmp_file
+  tmp_file="$(mktemp)"
 
-# Loop through each markdown post file
-for post in "$POSTS_DIR"/*.md; do
-    # Extract the title, excerpt, and author
-    title=$(awk '/^title:/{gsub(/^title: /,""); gsub(/'"'"'/,""); gsub(/"/,""); print; exit}' "$post")
-    author=$(awk '/^author:/{gsub(/^author: /,""); gsub(/'"'"'/,""); gsub(/"/,""); print; exit}' "$post")
+  awk -v image_line="image: \"$image_path\"" '
+    BEGIN {in_fm=0; fm_started=0; replaced=0}
+    NR==1 && $0=="---" {
+      fm_started=1
+      in_fm=1
+      print
+      next
+    }
+    in_fm==1 {
+      if ($0 ~ /^image:[[:space:]]*/) {
+        if (replaced==0) {
+          print image_line
+          replaced=1
+        }
+        next
+      }
+      if ($0=="---") {
+        if (replaced==0) {
+          print image_line
+          replaced=1
+        }
+        print
+        in_fm=0
+        next
+      }
+      print
+      next
+    }
+    { print }
+    END {
+      if (fm_started==0) {
+        print "Missing frontmatter in " FILENAME > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "$post_file" > "$tmp_file"
 
-    # Adjust title and excerpt to prevent overflow
-    adjusted_title=$(adjust_text "$title" 275 "$FONTS_DIR" "Work_Sans/WorkSans-VariableFont_wght.ttf")
+  mv "$tmp_file" "$post_file"
+}
 
-    # Create an image with the title, excerpt, and branding
-    jpg_file="$IMAGES_DIR/$(basename "$post" .md).jpg"
-    webp_file="$IMAGES_DIR/$(basename "$post" .md).webp"
-
-    # Check if author is "Hypha" and adjust accordingly
-    if [[ "$author" == "Hypha" ]]; then
-        # If author is Hypha, only show HYPHA on the left
-        convert -size 1200x627 xc:"#9900FC" \
-                \( -size 900x500 -background none -fill white -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 64 \
-                   label:"$adjusted_title" -gravity center \) -geometry +0+60  -composite \
-                -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
-                -gravity southwest -annotate +30+30 "HYPHA" \
-                "$IMAGES_DIR/$(basename "$post" .md).jpg"
+declare -a posts
+if [[ "$#" -gt 0 ]]; then
+  for post in "$@"; do
+    if [[ "$post" != /* ]]; then
+      posts+=("$REPO_ROOT/$post")
     else
-        # If author is not Hypha, show HYPHA on left and author name on right
-        convert -size 1200x627 xc:"#9900FC" \
-                \( -size 900x500 -background none -fill white -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 64 \
-                   label:"$adjusted_title" -gravity center \) -geometry +0+60  -composite \
-                -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
-                -gravity southwest -annotate +30+30 "HYPHA" \
-                -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 37 -fill white \
-                -gravity southeast -annotate +30+30 "$author" \
-                "$IMAGES_DIR/$(basename "$post" .md).jpg"
+      posts+=("$post")
     fi
+  done
+else
+  while IFS= read -r post; do
+    posts+=("$post")
+  done < <(find "$POSTS_DIR" -maxdepth 1 -type f -name '*.md' | sort)
+fi
 
-    # Convert JPG to WebP
-    cwebp -q 100 "$jpg_file" -o "$webp_file"
+if [[ "${#posts[@]}" -eq 0 ]]; then
+  echo "No posts to process."
+  exit 0
+fi
 
+for post in "${posts[@]}"; do
+  if [[ ! -f "$post" ]]; then
+    echo "Skipping missing post: $post" >&2
+    continue
+  fi
+
+  title="$(awk '/^title:/{val=$0; sub(/^title:[[:space:]]*/,"",val); if(length(val)>=2 && (c=substr(val,1,1))==substr(val,length(val)) && (c=="\"" || c=="'"'"'")) val=substr(val,2,length(val)-2); print val; exit}' "$post")"
+  author="$(awk '/^author:/{val=$0; sub(/^author:[[:space:]]*/,"",val); if(length(val)>=2 && (c=substr(val,1,1))==substr(val,length(val)) && (c=="\"" || c=="'"'"'")) val=substr(val,2,length(val)-2); print val; exit}' "$post")"
+
+  if [[ -z "$title" ]]; then
+    echo "Skipping post with no title: $post" >&2
+    continue
+  fi
+
+  adjusted_title="$(adjust_text "$title" 275 "$FONTS_DIR" "Work_Sans/WorkSans-VariableFont_wght.ttf")"
+  slug="$(basename "$post" .md)"
+  jpg_file="$IMAGES_DIR/$slug.jpg"
+  webp_file="$IMAGES_DIR/$slug.webp"
+  image_path="$IMAGE_PREFIX/$slug.webp"
+
+  if [[ "$author" == "Hypha" || -z "$author" ]]; then
+    convert -size 1200x627 xc:"#9900FC" \
+      \( -size 900x500 -background none -fill white -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 64 \
+      label:"$adjusted_title" -gravity center \) -geometry +0+60 -composite \
+      -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
+      -gravity southwest -annotate +30+30 "HYPHA" \
+      "$jpg_file"
+  else
+    convert -size 1200x627 xc:"#9900FC" \
+      \( -size 900x500 -background none -fill white -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 64 \
+      label:"$adjusted_title" -gravity center \) -geometry +0+60 -composite \
+      -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
+      -gravity southwest -annotate +30+30 "HYPHA" \
+      -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 37 -fill white \
+      -gravity southeast -annotate +30+30 "$author" \
+      "$jpg_file"
+  fi
+
+  cwebp -q 100 "$jpg_file" -o "$webp_file" >/dev/null
+  rm -f "$jpg_file"
+  upsert_image_frontmatter "$post" "$image_path"
+
+  echo "Generated $webp_file and updated $(basename "$post")"
 done
 
-# Clean up JPG files, keeping only WebP versions
-rm -f "$IMAGES_DIR"/*.jpg
-
-echo "Social cards generated in $IMAGES_DIR"
+echo "Social card generation complete."

--- a/social_cards_automation_scripts/createImagesFromPosts.sh
+++ b/social_cards_automation_scripts/createImagesFromPosts.sh
@@ -13,43 +13,33 @@ IMAGE_PREFIX="/assets/images/social/dripline"
 
 mkdir -p "$IMAGES_DIR"
 
-adjust_text() {
+IMAGEMAGICK_CMD="convert"
+if command -v magick >/dev/null 2>&1; then
+  IMAGEMAGICK_CMD="magick"
+fi
+
+render_text_image() {
   local text="$1"
-  local max_length="$2"
-  local font_dir="$3"
-  local font_file="$4"
-  local min_font_size="${5:-20}"
+  local max_width="$2"
+  local max_height="$3"
+  local font_dir="$4"
+  local font_file="$5"
+  local out_file="$6"
+  local min_font_size="${7:-20}"
 
   local font_size=76
-  local adjusted_text="$text"
-  local temp_file
-  temp_file="$(mktemp)"
-  local text_width
 
   while true; do
-    if ! convert -background none -fill white -font "$font_dir/$font_file" -pointsize "$font_size" label:"$adjusted_text" "$temp_file"; then
-      echo "Failed to render title text" >&2
-      rm -f "$temp_file"
-      return 1
-    fi
+    "$IMAGEMAGICK_CMD" -background none -fill white -font "$font_dir/$font_file" -pointsize "$font_size" -size "${max_width}x" -gravity center caption:"$text" "$out_file"
+    local text_height
+    text_height="$(identify -format "%h" "$out_file" 2>/dev/null || echo 9999)"
 
-    text_width="$(identify -format "%w" "$temp_file")"
-
-    if [[ "$text_width" -le "$max_length" || "$font_size" -le "$min_font_size" ]]; then
+    if [[ "$text_height" -le "$max_height" || "$font_size" -le "$min_font_size" ]]; then
       break
     fi
 
     font_size=$((font_size - 8))
   done
-
-  rm -f "$temp_file"
-
-  if [[ "$text_width" -gt "$max_length" ]]; then
-    local wrap_width=$((max_length / font_size * 2))
-    adjusted_text="$(echo "$adjusted_text" | fold -w "$wrap_width" -s)"
-  fi
-
-  echo "$adjusted_text"
 }
 
 upsert_image_frontmatter() {
@@ -132,29 +122,29 @@ for post in "${posts[@]}"; do
     continue
   fi
 
-  adjusted_title="$(adjust_text "$title" 275 "$FONTS_DIR" "Work_Sans/WorkSans-VariableFont_wght.ttf")"
+  temp_title_img="$(mktemp --suffix=.png)"
+  render_text_image "$title" 900 500 "$FONTS_DIR" "Work_Sans/WorkSans-VariableFont_wght.ttf" "$temp_title_img"
   slug="$(basename "$post" .md)"
   jpg_file="$IMAGES_DIR/$slug.jpg"
   webp_file="$IMAGES_DIR/$slug.webp"
   image_path="$IMAGE_PREFIX/$slug.webp"
 
   if [[ "$author" == "Hypha" || -z "$author" ]]; then
-    convert -size 1200x627 xc:"#9900FC" \
-      \( -size 900x500 -background none -fill white -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 64 \
-      label:"$adjusted_title" -gravity center \) -geometry +0+60 -composite \
+    "$IMAGEMAGICK_CMD" -size 1200x627 xc:"#9900FC" \
+      "$temp_title_img" -gravity center -geometry +0+60 -composite \
       -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
       -gravity southwest -annotate +30+30 "HYPHA" \
       "$jpg_file"
   else
-    convert -size 1200x627 xc:"#9900FC" \
-      \( -size 900x500 -background none -fill white -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 64 \
-      label:"$adjusted_title" -gravity center \) -geometry +0+60 -composite \
+    "$IMAGEMAGICK_CMD" -size 1200x627 xc:"#9900FC" \
+      "$temp_title_img" -gravity center -geometry +0+60 -composite \
       -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
       -gravity southwest -annotate +30+30 "HYPHA" \
       -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 37 -fill white \
       -gravity southeast -annotate +30+30 "$author" \
       "$jpg_file"
   fi
+  rm -f "$temp_title_img"
 
   cwebp -q 100 "$jpg_file" -o "$webp_file" >/dev/null
   rm -f "$jpg_file"

--- a/social_cards_automation_scripts/createImagesFromPosts.sh
+++ b/social_cards_automation_scripts/createImagesFromPosts.sh
@@ -48,7 +48,7 @@ upsert_image_frontmatter() {
   local tmp_file
   tmp_file="$(mktemp)"
 
-  awk -v image_line="image: \"$image_path\"" '
+  if awk -v image_line="image: \"$image_path\"" '
     BEGIN {in_fm=0; fm_started=0; replaced=0}
     NR==1 && $0=="---" {
       fm_started=1
@@ -80,12 +80,15 @@ upsert_image_frontmatter() {
     END {
       if (fm_started==0) {
         print "Missing frontmatter in " FILENAME > "/dev/stderr"
-        exit 1
+        exit 2
       }
     }
-  ' "$post_file" > "$tmp_file"
-
-  mv "$tmp_file" "$post_file"
+  ' "$post_file" > "$tmp_file"; then
+    mv "$tmp_file" "$post_file"
+  else
+    rm -f "$tmp_file"
+    return 1
+  fi
 }
 
 declare -a posts
@@ -130,25 +133,41 @@ for post in "${posts[@]}"; do
   image_path="$IMAGE_PREFIX/$slug.webp"
 
   if [[ "$author" == "Hypha" || -z "$author" ]]; then
-    "$IMAGEMAGICK_CMD" -size 1200x627 xc:"#9900FC" \
+    if ! "$IMAGEMAGICK_CMD" -size 1200x627 xc:"#9900FC" \
       "$temp_title_img" -gravity center -geometry +0+60 -composite \
       -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
       -gravity southwest -annotate +30+30 "HYPHA" \
-      "$jpg_file"
+      "$jpg_file"; then
+      echo "Failed to generate image for $slug" >&2
+      rm -f "$temp_title_img"
+      continue
+    fi
   else
-    "$IMAGEMAGICK_CMD" -size 1200x627 xc:"#9900FC" \
+    if ! "$IMAGEMAGICK_CMD" -size 1200x627 xc:"#9900FC" \
       "$temp_title_img" -gravity center -geometry +0+60 -composite \
       -font "$FONTS_DIR/Work_Sans/WorkSans-Black.ttf" -pointsize 37 -fill white \
       -gravity southwest -annotate +30+30 "HYPHA" \
       -font "$FONTS_DIR/Work_Sans/WorkSans-VariableFont_wght.ttf" -pointsize 37 -fill white \
       -gravity southeast -annotate +30+30 "$author" \
-      "$jpg_file"
+      "$jpg_file"; then
+      echo "Failed to generate image for $slug" >&2
+      rm -f "$temp_title_img"
+      continue
+    fi
   fi
   rm -f "$temp_title_img"
 
-  cwebp -q 100 "$jpg_file" -o "$webp_file" >/dev/null
+  if ! cwebp -q 100 "$jpg_file" -o "$webp_file" >/dev/null 2>&1; then
+    echo "Failed to convert to webp for $slug" >&2
+    rm -f "$jpg_file"
+    continue
+  fi
   rm -f "$jpg_file"
-  upsert_image_frontmatter "$post" "$image_path"
+  
+  if ! upsert_image_frontmatter "$post" "$image_path"; then
+    echo "Skipped updating frontmatter for $(basename "$post") due to missing frontmatter." >&2
+    continue
+  fi
 
   echo "Generated $webp_file and updated $(basename "$post")"
 done

--- a/social_cards_automation_scripts/createImagesFromPosts.sh
+++ b/social_cards_automation_scripts/createImagesFromPosts.sh
@@ -30,7 +30,10 @@ render_text_image() {
   local font_size=76
 
   while true; do
-    "$IMAGEMAGICK_CMD" -background none -fill white -font "$font_dir/$font_file" -pointsize "$font_size" -size "${max_width}x" -gravity center caption:"$text" "$out_file"
+    if ! "$IMAGEMAGICK_CMD" -background none -fill white -font "$font_dir/$font_file" -pointsize "$font_size" -size "${max_width}x" -gravity center caption:"$text" "$out_file"; then
+      echo "Failed to render caption text for '$text'" >&2
+      return 1
+    fi
     local text_height
     text_height="$(identify -format "%h" "$out_file" 2>/dev/null || echo 9999)"
 
@@ -126,8 +129,13 @@ for post in "${posts[@]}"; do
   fi
 
   temp_title_img="$(mktemp --suffix=.png)"
-  render_text_image "$title" 900 500 "$FONTS_DIR" "Work_Sans/WorkSans-VariableFont_wght.ttf" "$temp_title_img"
   slug="$(basename "$post" .md)"
+  
+  if ! render_text_image "$title" 900 500 "$FONTS_DIR" "Work_Sans/WorkSans-VariableFont_wght.ttf" "$temp_title_img"; then
+    echo "Skipping $slug due to text rendering failure." >&2
+    rm -f "$temp_title_img"
+    continue
+  fi
   jpg_file="$IMAGES_DIR/$slug.jpg"
   webp_file="$IMAGES_DIR/$slug.webp"
   image_path="$IMAGE_PREFIX/$slug.webp"


### PR DESCRIPTION
Automates social card generation in CI when a new file is added in the posts directory.

- Detects newly added markdown files under _posts on push
- Generates social cards for those posts only
- Writes images to assets/images/social/dripline
- Upserts image frontmatter in each new post
- Commits updated post plus generated image back to the branch