### PR TITLE
Add data-label-1 to newsletter signup form

### DIFF
--- a/_includes/sections/newsletter.html
+++ b/_includes/sections/newsletter.html
@@ -13,7 +13,7 @@
             <div class="w-100 w-third-l mt3 mt0-l">
                 <div style="min-height: 58px;max-width: 440px;margin: 0;width: 100%">
                     <script src="https://cdn.jsdelivr.net/ghost/signup-form@~0.2/umd/signup-form.min.js"
-                        data-button-color="#9900FC" data-button-text-color="#FFFFFF"
+                        data-label-1="newsletter" data-button-color="#9900FC" data-button-text-color="#FFFFFF"
                         data-site="https://newsletter.hypha.coop/" data-locale="en" async>
                         </script>
                 </div>


### PR DESCRIPTION
Adds `data-label-1="newsletter"` to the Ghost signup form script tag in `_includes/sections/newsletter.html`.

This tags new subscribers with a "newsletter" label in Ghost, making it easier to identify how they signed up.

## Testing
- Build the site and verify `data-label-1="newsletter"` appears on the signup script tag in the rendered HTML
- Test the signup flow and confirm the label appears in Ghost admin for new subscribers