### PR TITLE
Add valence and streamplace to work categories

### DIFF
--- a/_data/work_categories.yml
+++ b/_data/work_categories.yml
@@ -12,6 +12,7 @@
     - cosmos
     - isle-testnet
     - loro-testnet
+    - valence
 
 - name: "Cultural Infrastructure & Digital Public Goods"
   projects:
@@ -24,6 +25,7 @@
   projects:
     - distributed-press
     - compost
+    - streamplace
 
 - name: "Collaborative Futures & Experimental Practice"
   projects:

--- a/_includes/sections/newsletter.html
+++ b/_includes/sections/newsletter.html
@@ -13,7 +13,7 @@
             <div class="w-100 w-third-l mt3 mt0-l">
                 <div style="min-height: 58px;max-width: 440px;margin: 0;width: 100%">
                     <script src="https://cdn.jsdelivr.net/ghost/signup-form@~0.2/umd/signup-form.min.js"
-                        data-label-1="newsletter" data-button-color="#9900FC" data-button-text-color="#FFFFFF"
+                        data-button-color="#9900FC" data-button-text-color="#FFFFFF"
                         data-site="https://newsletter.hypha.coop/" data-locale="en" async>
                         </script>
                 </div>


### PR DESCRIPTION
Adds the two projects missing from `_data/work_categories.yml` that exist in `_work/`:

- **valence** → "Blockchain Infrastructure & Protocol Development" (cross-chain DeFi / Interchain Operations)
- **streamplace** → "Decentralized Publishing & Content Distribution" (decentralized social video, AT Protocol)