### PR TITLE
Harden deploy workflow and guard Sequoia publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,14 @@ jobs:
 
       # Publish to AT Protocol 
       # Only on push to master  (avoids publishing staging content to prod PDS)
+      - name: Sync Sequoia state before publish
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: sequoia sync --update-frontmatter
+
+      - name: Check for duplicate Sequoia paths
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: python3 _scripts/check_sequoia_duplicates.py
+
       - name: Publish to ATProto
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       # Only on push to master 
       - name: Install Sequoia
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: npm i -g sequoia-cli@0.5.3
+        run: npm i -g sequoia-cli@0.5.4
 
 
 
@@ -125,4 +125,3 @@ jobs:
       - name: Remove decoded AP key
         if: always()
         run: rm -f "$DP_AP_KEY_PATH"
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,35 +12,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DP_AP_KEY_PATH: ${{ runner.temp }}/dp-ap-${{ github.run_id }}-${{ github.run_attempt }}.key
     steps:
-      # Get system info
-      - run: ifconfig
-      - run: sudo dmidecode
-      - run: df -h
-      - run: free -m
       - run: echo "GitHub branch is ${{ github.ref }}"
 
-      # Conditional checkout for PRs
-      - name: Checkout PR branch
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-
-      # Standard checkout for non-PR events
       - name: Checkout repo
-        if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
-
-      # Install Brotli development headers (Fix for ruby-brs gem)
-      - name: Install Brotli dependencies
-        run: sudo apt-get update && sudo apt-get install -y libbrotli-dev
+        uses: actions/checkout@v4.3.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
       # Install Sequoia (AT Protocol / Standard.site)
       # Only on push to master 
       - name: Install Sequoia
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: npm i -g sequoia-cli
+        run: npm i -g sequoia-cli@0.5.3
 
 
 
@@ -55,12 +41,13 @@ jobs:
 
       # Build Jekyll Site
       - run: echo "Building Jekyll site"
-      - run: sudo gem install bundler
-      - run: sudo gem install jekyll
-      - run: sudo bundle install
+      - run: gem install bundler
+      - run: gem install jekyll
+      - run: bundle install
 
       - name: Set DP Social URL based on branch
         run: |
+          set -euo pipefail
           if [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
             sed -i 's|url: "https://social.dp.chanterelle.xyz"|url: "${{ vars.SOCIAL_DP_PROD }}"|' _config.yml
           elif [[ "${{ github.ref }}" == "refs/heads/staging" ]] || [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "staging" ]]; then
@@ -73,13 +60,19 @@ jobs:
         if: >
           github.ref == 'refs/heads/staging' ||
           (github.event_name == 'pull_request' && github.base_ref == 'staging')
-        run: echo ${{ secrets.ENCODED_DP_AP_KEY_STAGING }} | base64 --decode > /tmp/secret.key
+        run: |
+          set -euo pipefail
+          install -m 600 /dev/null "$DP_AP_KEY_PATH"
+          printf '%s' '${{ secrets.ENCODED_DP_AP_KEY_STAGING }}' | base64 --decode > "$DP_AP_KEY_PATH"
 
       - name: Decode Production Key
         if: >
           github.ref == 'refs/heads/master' ||
           (github.event_name == 'pull_request' && github.base_ref == 'master')
-        run: echo ${{ secrets.ENCODED_DP_AP_KEY_PRODUCTION }} | base64 --decode > /tmp/secret.key
+        run: |
+          set -euo pipefail
+          install -m 600 /dev/null "$DP_AP_KEY_PATH"
+          printf '%s' '${{ secrets.ENCODED_DP_AP_KEY_PRODUCTION }}' | base64 --decode > "$DP_AP_KEY_PATH"
 
       - name: Build Jekyll Site for Staging
         if: github.ref == 'refs/heads/staging' || (github.event_name == 'pull_request' && github.base_ref == 'staging')
@@ -118,15 +111,18 @@ jobs:
 
       - name: Notify AP
         if: github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.base_ref == 'master')
-        run: bundle exec jekyll notify --key /tmp/secret.key --verbose --trace
+        run: bundle exec jekyll notify --key "$DP_AP_KEY_PATH" --verbose --trace
 
       - name: Commit ActivityPub and Sequoia Data
         if: github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.base_ref == 'master')
-        uses: EndBug/add-and-commit@v9 
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
         with:
           add: '_data/activity_pub.yml,.sequoia-state.json,_posts'
           default_author: github_actions
           message: 'Commit ActivityPub and Sequoia data'
           fetch: true
 
+      - name: Remove decoded AP key
+        if: always()
+        run: rm -f "$DP_AP_KEY_PATH"
 

--- a/_scripts/check_sequoia_duplicates.py
+++ b/_scripts/check_sequoia_duplicates.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SEQUOIA_CONFIG = REPO_ROOT / "sequoia.json"
+
+
+def load_json(path: Path):
+    with path.open() as f:
+        return json.load(f)
+
+
+def fetch_json(url: str):
+    with urllib.request.urlopen(url) as response:
+        return json.load(response)
+
+
+def parse_at_uri(uri: str):
+    if not uri.startswith("at://"):
+        raise ValueError(f"Invalid AT URI: {uri}")
+    parts = uri[5:].split("/")
+    if len(parts) != 3:
+        raise ValueError(f"Invalid AT URI: {uri}")
+    return parts[0], parts[1], parts[2]
+
+
+def resolve_post_path(post_file: Path, path_prefix: str):
+    name = post_file.stem
+    if len(name) > 11 and name[4] == "-" and name[7] == "-":
+        slug = name[11:]
+    else:
+        slug = name
+    path_prefix = path_prefix.rstrip("/")
+    return f"{path_prefix}/{slug}" if path_prefix else f"/{slug}"
+
+
+def list_documents(pds_url: str, did: str):
+    records = []
+    cursor = None
+    while True:
+        params = {
+            "repo": did,
+            "collection": "site.standard.document",
+            "limit": 100,
+        }
+        if cursor:
+            params["cursor"] = cursor
+        url = f"{pds_url}/xrpc/com.atproto.repo.listRecords?{urllib.parse.urlencode(params)}"
+        payload = fetch_json(url)
+        records.extend(payload.get("records", []))
+        cursor = payload.get("cursor")
+        if not cursor:
+            break
+    return records
+
+
+def main():
+    config = load_json(SEQUOIA_CONFIG)
+    did, _, _ = parse_at_uri(config["publicationUri"])
+    did_doc = fetch_json(f"https://plc.directory/{did}")
+    services = did_doc.get("service", [])
+    pds_url = None
+    for service in services:
+        if service.get("type") == "AtprotoPersonalDataServer":
+            pds_url = service.get("serviceEndpoint")
+            break
+    if not pds_url:
+        print("Could not determine PDS endpoint from DID document.", file=sys.stderr)
+        return 2
+
+    records = list_documents(pds_url.rstrip("/"), did)
+    publication_uri = config["publicationUri"]
+
+    local_paths = {}
+    content_dir = REPO_ROOT / config["contentDir"]
+    for post_file in sorted(content_dir.glob("*.md")):
+        local_paths[resolve_post_path(post_file, config.get("pathPrefix", ""))] = post_file
+
+    duplicates = defaultdict(list)
+    for record in records:
+        value = record.get("value", {})
+        if value.get("$type") != "site.standard.document":
+            continue
+        if value.get("site") != publication_uri:
+            continue
+        path = value.get("path")
+        if path in local_paths:
+            duplicates[path].append(record)
+
+    duplicate_paths = {path: items for path, items in duplicates.items() if len(items) > 1}
+    if not duplicate_paths:
+        print("No duplicate Sequoia document paths found.")
+        return 0
+
+    print("Duplicate Sequoia document paths found:", file=sys.stderr)
+    for path, items in sorted(duplicate_paths.items()):
+        print(f"- {path} ({len(items)} records)", file=sys.stderr)
+        print(f"  local file: {local_paths[path]}", file=sys.stderr)
+        for item in items:
+            uri = item.get("uri", "<missing-uri>")
+            value = item.get("value", {})
+            has_text = "textContent" in value
+            print(f"  - {uri} textContent={str(has_text).lower()}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.URLError as exc:
+        print(f"Failed to query ATProto data: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -14,9 +14,8 @@ PORT="${4:-22}"
 SITE_DIR="${5:-/var/www/html}"
 
 # This is done to skip the fingerprint check on new connection
-# - Skip the host fingerprint check
-# - Don't save the fingerprint to known_hosts
+# - Accept first-seen keys while still preventing changed-key MITM attacks
 rsync -v -r \
   --delete-after \
-  -e "ssh -i $IDENTITY_FILE -o StrictHostKeyChecking=no -p $PORT" \
+  -e "ssh -i $IDENTITY_FILE -o StrictHostKeyChecking=accept-new -p $PORT" \
   ./_site/* $USER@$SERVER:$SITE_DIR

--- a/social_cards_automation_scripts/README.md
+++ b/social_cards_automation_scripts/README.md
@@ -11,5 +11,5 @@ The second script adds the 'image' variable pointing to the image in the post's 
 
 These scripts are a work in progress. Be sure to read the comments before running these scripts.
 You will need to change paths or move the scripts to the adequate folder.
-The editPosts.sh script currently writes duplicated 'image' variables and required some manual editing.
-This duplication should be looked into for full automation and to prevent the currently needed manual fixes.
+The `editPosts.sh` script now updates the `image` field only within the YAML front matter and avoids duplicate keys.
+It still assumes posts live directly in the target directory and that each file already has a valid front matter block.

--- a/social_cards_automation_scripts/editPosts.sh
+++ b/social_cards_automation_scripts/editPosts.sh
@@ -1,36 +1,57 @@
 #!/bin/bash
 
-# This script is a work in progress. 
-# It needs to be fine-tuned to work properly without duplicating the image variable in the front matter.
-# Directory where your markdown post files are stored
-# This script assumes that the markdown files are in the root of the _posts directory
-POSTS_DIR="./"
+set -euo pipefail
 
-# Directory where images are stored
+# This script assumes markdown posts live directly in the target directory.
+POSTS_DIR="${1:-./}"
 IMAGES_DIR="/assets/images/social/dripline"
 
-# Loop through each markdown post file
 for post in "$POSTS_DIR"/*.md; do
-    # Determine the WebP file name from the markdown file name
+    [ -e "$post" ] || continue
+
     webp_file="$(basename "$post" .md).webp"
+    image_value="$IMAGES_DIR/$webp_file"
 
-    # Path to the WebP image to be included in the front matter
-    image_path="image: \"$IMAGES_DIR/$webp_file\""
+    awk -v image_value="$image_value" '
+        BEGIN {
+            in_frontmatter = 0
+            frontmatter_done = 0
+            image_written = 0
+        }
+        NR == 1 && $0 == "---" {
+            in_frontmatter = 1
+            print
+            next
+        }
+        in_frontmatter && $0 == "---" {
+            if (!image_written) {
+                print "image: \"" image_value "\""
+                image_written = 1
+            }
+            in_frontmatter = 0
+            frontmatter_done = 1
+            print
+            next
+        }
+        in_frontmatter && $0 ~ /^image:[[:space:]]*/ {
+            if (!image_written) {
+                print "image: \"" image_value "\""
+                image_written = 1
+            }
+            next
+        }
+        {
+            print
+        }
+        END {
+            if (!frontmatter_done) {
+                exit 2
+            }
+        }
+    ' "$post" > "$post.tmp"
 
-    # Check if the file already contains an 'image:' line
-    if grep -q "^image:" "$post"; then
-        # The file contains an image line, replace it
-        sed -i'' "/^image:/c\\$image_path" "$post"
-    else
-        # No image line, add one. Ensure it's only added within the front matter
-        # Assuming the front matter starts and ends with '---'
-        # This sed command inserts the image path after the first line of ---
-        sed -i'' "/^---$/a\\
-$image_path
-" "$post"
-    fi
-
-    echo "Updated $post with new image path: $image_path"
+    mv "$post.tmp" "$post"
+    echo "Updated $post with image: $image_value"
 done
 
 echo "All markdown files have been updated."


### PR DESCRIPTION
## Summary

This PR hardens the deploy workflow and adds guardrails around `standard.site` / Sequoia publishing.

Closes #554

## What changed

- harden deploy workflow secret handling and cleanup
- pin `actions/checkout`, `EndBug/add-and-commit`, and `sequoia-cli`
- remove noisy runner debug steps and dead Brotli install
- switch deploy SSH from `StrictHostKeyChecking=no` to `accept-new`
- fix `social_cards_automation_scripts/editPosts.sh` so it updates frontmatter without duplicating `image:` keys
- run `sequoia sync --update-frontmatter` before publish
- fail publish when duplicate remote `site.standard.document` paths already exist for local posts

## Why

We confirmed that duplicate `site.standard.document` records already exist on the PDS for several recent posts. We also verified from Sequoia's current code path that publish decides `create` vs `update` from frontmatter `atUri`, so missing frontmatter mappings can silently create new remote records.

This PR does not clean up old duplicate records. It prevents further silent duplication and makes the current failure mode explicit in CI until the remote state is repaired.

## Verification

- workflow YAML parses
- shell scripts pass syntax checks
- `editPosts.sh` was exercised against a temp markdown file
- duplicate checker was run against the live PDS and correctly detected existing duplicate paths
