### PR TITLE
Add noindex meta tag for staging builds

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% if jekyll.environment == "staging" %}<meta name="robots" content="noindex">{% endif %}
   <title>{{ meta_section }}{{ meta_title }}</title>
   <script defer data-domain="hypha.coop" src="https://analytics.hypha.coop/js/script.js"></script>
 


### PR DESCRIPTION
## What

Adds `<meta name="robots" content="noindex">` to staging builds only, so `staging.hypha.coop` is not indexed by search engines.

## How

Gated on `jekyll.environment == "staging"` in `_includes/head.html`. CI sets `JEKYLL_ENV=staging` for staging deploys (`.github/workflows/deploy.yml:87` → `make build-dweb`), while production runs `make build-dweb` with the default `development` environment, so prod stays indexable.

## Notes

There was no prior indexing control for staging — no `robots.txt` and no existing robots meta tag in the repo, so staging was fully crawlable until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)